### PR TITLE
feat: org-scoped admin secret

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -25,6 +25,7 @@ export class HubDB {
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         api_key TEXT UNIQUE NOT NULL,
+        admin_secret TEXT,
         persist_messages INTEGER DEFAULT 1,
         created_at INTEGER NOT NULL
       );
@@ -73,6 +74,20 @@ export class HubDB {
       CREATE INDEX IF NOT EXISTS idx_channels_org ON channels(org_id);
       CREATE INDEX IF NOT EXISTS idx_channel_members_agent ON channel_members(agent_id);
     `);
+
+    // Migration: add admin_secret to existing orgs that don't have it
+    try {
+      this.db.exec(`ALTER TABLE orgs ADD COLUMN admin_secret TEXT`);
+    } catch {
+      // Column already exists
+    }
+    // Generate admin_secret for orgs that don't have one
+    const orgsWithoutSecret = this.db.prepare('SELECT id FROM orgs WHERE admin_secret IS NULL').all() as any[];
+    for (const org of orgsWithoutSecret) {
+      const secret = crypto.randomBytes(24).toString('hex');
+      this.db.prepare('UPDATE orgs SET admin_secret = ? WHERE id = ?').run(secret, org.id);
+      console.log(`  🔐 Generated admin_secret for org ${org.id}`);
+    }
   }
 
   // ─── Org Operations ──────────────────────────────────────
@@ -82,12 +97,13 @@ export class HubDB {
       id: uuid(),
       name,
       api_key: crypto.randomBytes(24).toString('hex'),
+      admin_secret: crypto.randomBytes(24).toString('hex'),
       persist_messages: persistMessages,
       created_at: Date.now(),
     };
     this.db.prepare(
-      'INSERT INTO orgs (id, name, api_key, persist_messages, created_at) VALUES (?, ?, ?, ?, ?)'
-    ).run(org.id, org.name, org.api_key, org.persist_messages ? 1 : 0, org.created_at);
+      'INSERT INTO orgs (id, name, api_key, admin_secret, persist_messages, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(org.id, org.name, org.api_key, org.admin_secret, org.persist_messages ? 1 : 0, org.created_at);
     return org;
   }
 
@@ -95,6 +111,11 @@ export class HubDB {
     const row = this.db.prepare('SELECT * FROM orgs WHERE api_key = ?').get(apiKey) as any;
     if (!row) return undefined;
     return { ...row, persist_messages: !!row.persist_messages };
+  }
+
+  verifyOrgAdminSecret(orgId: string, secret: string): boolean {
+    const row = this.db.prepare('SELECT admin_secret FROM orgs WHERE id = ?').get(orgId) as any;
+    return row?.admin_secret === secret;
   }
 
   getOrgById(id: string): Org | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ function main() {
 
   // API routes
   const server = createServer(app);
-  const hubWs = new HubWS(server, db, config);
+  const hubWs = new HubWS(server, db);
   app.use(createRouter(db, hubWs, config));
 
   // Fallback: serve index.html for SPA routing

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -102,15 +102,19 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig): Router {
   });
 
   /**
-   * DELETE /api/agents/:id — Remove an agent (admin only)
-   * Auth: Admin secret (not org key — agents have org key, so it's not safe)
+   * DELETE /api/agents/:id — Remove an agent (org admin only)
+   * Auth: Org API Key + Org Admin Secret (via X-Admin-Secret header)
    */
-  router.delete('/api/agents/:id', (req, res) => {
-    if (!requireAdmin(req, res)) return;
+  auth.delete('/api/agents/:id', requireOrg, (req, res) => {
+    // Require org admin secret
+    const adminSecret = req.headers['x-admin-secret'] as string;
+    if (!adminSecret || !db.verifyOrgAdminSecret(req.org!.id, adminSecret)) {
+      res.status(403).json({ error: 'Org admin secret required' });
+      return;
+    }
 
-    // Admin needs to specify which org via query param or we look up the agent directly
     const agent = db.getAgentById(req.params.id as string);
-    if (!agent) {
+    if (!agent || agent.org_id !== req.org!.id) {
       res.status(404).json({ error: 'Agent not found' });
       return;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface Org {
   id: string;
   name: string;
   api_key: string;
+  admin_secret: string;
   persist_messages: boolean;
   created_at: number;
 }

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,7 +1,7 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import type { Server } from 'node:http';
 import type { HubDB } from './db.js';
-import type { HubConfig, Message, WsServerEvent } from './types.js';
+import type { Message, WsServerEvent } from './types.js';
 import { URL } from 'node:url';
 
 interface WsClient {
@@ -15,11 +15,9 @@ export class HubWS {
   private wss: WebSocketServer;
   private clients: Set<WsClient> = new Set();
   private db: HubDB;
-  private config: HubConfig;
 
-  constructor(server: Server, db: HubDB, config: HubConfig) {
+  constructor(server: Server, db: HubDB) {
     this.db = db;
-    this.config = config;
     this.wss = new WebSocketServer({ server, path: '/ws' });
 
     this.wss.on('connection', (ws, req) => {
@@ -53,13 +51,13 @@ export class HubWS {
         return;
       }
 
-      // Try org key + admin secret (for web UI / human admins)
+      // Try org key + org admin secret (for web UI / human admins)
       const org = db.getOrgByKey(token);
       if (org) {
-        // Require admin secret for org-level access
+        // Require org-scoped admin secret
         const adminToken = url.searchParams.get('admin');
-        if (this.config.admin_secret && adminToken !== this.config.admin_secret) {
-          ws.close(4003, 'Admin secret required for org-level access');
+        if (!adminToken || !db.verifyOrgAdminSecret(org.id, adminToken)) {
+          ws.close(4003, 'Org admin secret required for console access');
           return;
         }
 

--- a/web/index.html
+++ b/web/index.html
@@ -286,13 +286,17 @@ const API = window.location.origin + basePath;
 
 // ─── API Helpers ─────────────────────────────────────────────
 async function api(path, opts = {}) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${apiKey}`,
+    ...opts.headers,
+  };
+  if (adminSecret) {
+    headers['X-Admin-Secret'] = adminSecret;
+  }
   const res = await fetch(API + path, {
     ...opts,
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`,
-      ...opts.headers,
-    },
+    headers,
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));


### PR DESCRIPTION
## What

Replaces global `BOTSHUB_ADMIN_SECRET` for org-level operations with **per-org admin secrets**.

Each org now has its own `admin_secret`, generated on creation. Existing orgs get one auto-generated via DB migration.

## Permission model (4-tier)

| Level | Auth | Can do |
|-------|------|--------|
| **Platform admin** | `BOTSHUB_ADMIN_SECRET` (env var) | Create orgs, list orgs |
| **Org admin** | Org API Key + **Org Admin Secret** | Delete agents, Web Console |
| **Org member** | Org API Key | Register agents, list agents/channels |
| **Agent** | Agent Token | Send/receive messages, deregister self |

## Changes

- `orgs` table: added `admin_secret` column + migration for existing orgs
- `POST /api/orgs` response now includes `admin_secret`
- `DELETE /api/agents/:id`: requires `X-Admin-Secret` header (org-scoped)
- WebSocket org access: `?token=<org_key>&admin=<org_admin_secret>`
- Web UI: sends `X-Admin-Secret` on all API calls
- `HubWS` no longer needs global config — uses `db.verifyOrgAdminSecret()`

## Migration

Existing orgs automatically get a generated `admin_secret`. Check the startup logs or query the DB:
```sql
SELECT name, admin_secret FROM orgs;
```

Web UI users need to clear localStorage and re-login with both keys.