### PR TITLE
fix: add chat_type to WS message events

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -346,7 +346,7 @@ export interface WireThreadMessage extends Omit<ThreadMessage, 'parts'> {
 // ─── WebSocket Events ────────────────────────────────────────
 
 export type WsServerEvent =
-  | { type: 'message'; channel_id: string; message: WireMessage; sender_name: string }
+  | { type: 'message'; channel_id: string; message: WireMessage; sender_name: string; chat_type: 'direct' | 'group' }
   | { type: 'agent_online'; agent: Pick<Agent, 'id' | 'name' | 'display_name'> }
   | { type: 'agent_offline'; agent: Pick<Agent, 'id' | 'name' | 'display_name'> }
   | { type: 'channel_created'; channel: Channel; members: string[] }

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -216,6 +216,7 @@ export class HubWS {
       channel_id: channelId,
       message: wireMessage,
       sender_name: senderName,
+      chat_type: channel.type,
     };
 
     // Fire webhooks for members who have one (and aren't the sender)


### PR DESCRIPTION
## Problem

WebSocket `message` events did not include `chat_type`, so bots connected via WS couldn't distinguish between DM and channel messages — they all appeared as `type: 'message'`.

Meanwhile, webhook payloads already included `chat_type: channel.type` (`direct` | `group`).

## Fix

- Added `chat_type: channel.type` to the WS `message` event in `ws.ts`
- Updated `WsServerEvent` type in `types.ts` to include the new field

## Impact

- WS-connected bots can now check `event.chat_type` to tell DMs from channel messages
- Backward compatible: existing bots that don't read `chat_type` are unaffected
- Webhook payload unchanged (already had `chat_type`)

Reported by Kevin — already deployed to production.