### PR TITLE
feat(auth): ticket-based login, registration, role enforcement (Phase 2)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -122,6 +122,24 @@ export function requireOrg(req: Request, res: Response, next: NextFunction) {
 }
 
 /**
+ * Middleware factory: Require a specific auth_role on the current agent.
+ * Only agents with the specified role can proceed.
+ */
+export function requireAuthRole(role: 'admin') {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.agent) {
+      res.status(403).json({ error: 'Agent authentication required', code: 'FORBIDDEN' });
+      return;
+    }
+    if (req.agent.auth_role !== role) {
+      res.status(403).json({ error: `Auth role '${role}' required`, code: 'FORBIDDEN' });
+      return;
+    }
+    next();
+  };
+}
+
+/**
  * Middleware factory: Require a specific scope on the current token.
  * The operation name maps to SCOPE_REQUIREMENTS in types.ts.
  */

--- a/src/db.ts
+++ b/src/db.ts
@@ -760,6 +760,30 @@ export class HubDB {
     return crypto.timingSafeEqual(expected, actual);
   }
 
+  /**
+   * Verify the org secret (used for ticket-based login).
+   * In the current schema, org_secret = admin_secret.
+   * Phase 7 will separate them into distinct columns.
+   */
+  verifyOrgSecret(orgId: string, secret: string): boolean {
+    return this.verifyOrgAdminSecret(orgId, secret);
+  }
+
+  /**
+   * Set the auth_role for an agent ('admin' or 'member').
+   */
+  setAgentAuthRole(agentId: string, role: 'admin' | 'member'): void {
+    this.db.prepare('UPDATE agents SET auth_role = ? WHERE id = ?').run(role, agentId);
+  }
+
+  /**
+   * Rotate the org secret (admin_secret) to a new hash.
+   * Phase 7 will separate org_secret from admin_secret.
+   */
+  rotateOrgSecret(orgId: string, newSecretHash: string): void {
+    this.db.prepare('UPDATE orgs SET admin_secret = ? WHERE id = ?').run(newSecretHash, orgId);
+  }
+
   getOrgById(id: string): Org | undefined {
     const row = this.db.prepare('SELECT * FROM orgs WHERE id = ?').get(id) as any;
     if (!row) return undefined;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,9 +4,9 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { HubDB } from './db.js';
+import { HubDB } from './db.js';
 import type { HubWS } from './ws.js';
-import { authMiddleware, requireAgent, requireOrg, requireScope } from './auth.js';
+import { authMiddleware, requireAgent, requireOrg, requireScope, requireAuthRole } from './auth.js';
 import { validateWebhookUrl } from './webhook.js';
 import { validateParts, VALID_TOKEN_SCOPES, type HubConfig, type Agent, type AgentProfileInput, type Thread, type ThreadStatus, type CloseReason, type ArtifactType, type MessagePart, type Message, type ThreadMessage, type WireMessage, type WireThreadMessage, type CatchupResponse, type CatchupCountResponse, type OrgSettings, type TokenScope, type ThreadPermissionPolicy } from './types.js';
 import { issueWsTicket } from './ws-tickets.js';
@@ -61,6 +61,7 @@ function toAgentResponse(agent: Agent) {
     org_id: agent.org_id,
     name: agent.name,
     display_name: agent.display_name,
+    auth_role: agent.auth_role,
     online: agent.online,
     last_seen_at: agent.last_seen_at,
     created_at: agent.created_at,
@@ -291,6 +292,277 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig): Router {
     if (!requireAdmin(req, res)) return;
     const orgs = db.listOrgs().map(({ api_key, admin_secret, ...safe }) => safe);
     res.json(orgs);
+  });
+
+  // ─── Shared Registration Validation ───────────────────────
+
+  /**
+   * Validate and extract agent registration fields from a request body.
+   * Returns the validated fields or sends an error response and returns null.
+   */
+  async function validateRegistrationBody(
+    body: any,
+    res: import('express').Response,
+  ): Promise<{
+    name: string;
+    display_name?: string;
+    metadata?: Record<string, unknown> | null;
+    webhook_url?: string | null;
+    webhook_secret?: string | null;
+    profile: AgentProfileInput;
+  } | null> {
+    const {
+      name,
+      display_name,
+      metadata,
+      webhook_url,
+      webhook_secret,
+      bio,
+      role,
+      function: functionName,
+      team,
+      tags,
+      languages,
+      protocols,
+      status_text,
+      timezone,
+      active_hours,
+      version,
+      runtime,
+    } = body;
+
+    if (!name) {
+      res.status(400).json({ error: 'name is required', code: 'VALIDATION_ERROR' });
+      return null;
+    }
+
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      res.status(400).json({ error: 'name must be alphanumeric (a-z, 0-9, _, -)', code: 'VALIDATION_ERROR' });
+      return null;
+    }
+
+    // Per-field size limits
+    const fieldError = checkFieldLimits({ name, display_name, metadata, webhook_url, bio, role, function: functionName, team, tags, languages, protocols, status_text, timezone, active_hours, version, runtime });
+    if (fieldError) {
+      res.status(400).json({ error: fieldError });
+      return null;
+    }
+
+    // Validate profile field types
+    const stringFields = { bio, role, function: functionName, team, status_text, timezone, active_hours, version, runtime };
+    for (const [key, val] of Object.entries(stringFields)) {
+      if (val !== undefined && val !== null && typeof val !== 'string') {
+        res.status(400).json({ error: `${key} must be a string or null` });
+        return null;
+      }
+    }
+    for (const [key, val] of Object.entries({ tags, languages }) as [string, unknown][]) {
+      if (val !== undefined && val !== null && (!Array.isArray(val) || !val.every((v: unknown) => typeof v === 'string'))) {
+        res.status(400).json({ error: `${key} must be an array of strings or null` });
+        return null;
+      }
+    }
+    if (protocols !== undefined && protocols !== null && typeof protocols !== 'object') {
+      res.status(400).json({ error: 'protocols must be an object or null' });
+      return null;
+    }
+
+    const profile: AgentProfileInput = {
+      bio,
+      role,
+      function: functionName,
+      team,
+      tags,
+      languages,
+      protocols,
+      status_text,
+      timezone,
+      active_hours,
+      version,
+      runtime,
+    };
+
+    // SSRF protection: validate webhook URL at set time
+    if (webhook_url) {
+      const urlError = await validateWebhookUrl(webhook_url);
+      if (urlError) {
+        res.status(400).json({ error: urlError });
+        return null;
+      }
+    }
+
+    return { name, display_name, metadata, webhook_url, webhook_secret, profile };
+  }
+
+  // ─── Public Auth Routes (Ticket-Based) ──────────────────
+
+  /**
+   * POST /api/auth/login — Authenticate with org credentials and receive a ticket
+   * Body: { org_id, org_secret, reusable?, expires_in? }
+   * Returns: { ticket, expires_at, reusable, org: { id, name } }
+   */
+  router.post('/api/auth/login', (req, res) => {
+    const { org_id, org_secret, reusable, expires_in } = req.body;
+
+    // Validate required fields
+    if (!org_id || typeof org_id !== 'string') {
+      res.status(400).json({ error: 'org_id is required', code: 'VALIDATION_ERROR' });
+      return;
+    }
+    if (!org_secret || typeof org_secret !== 'string') {
+      res.status(400).json({ error: 'org_secret is required', code: 'VALIDATION_ERROR' });
+      return;
+    }
+
+    // Look up org
+    const org = db.getOrgById(org_id);
+    if (!org) {
+      res.status(404).json({ error: 'Organization not found', code: 'NOT_FOUND' });
+      return;
+    }
+
+    // Verify org_secret
+    if (!db.verifyOrgSecret(org.id, org_secret)) {
+      res.status(401).json({ error: 'Invalid org secret', code: 'INVALID_SECRET' });
+      return;
+    }
+
+    // Check org status
+    if (org.status !== 'active') {
+      const code = org.status === 'suspended' ? 'ORG_SUSPENDED' : 'ORG_DESTROYED';
+      res.status(403).json({ error: `Organization is ${org.status}`, code });
+      return;
+    }
+
+    // Calculate expiry
+    const expiresInSec = typeof expires_in === 'number' && expires_in > 0 ? expires_in : 1800;
+    const expiresAt = Date.now() + expiresInSec * 1000;
+
+    // Store the hash of the plaintext org_secret in the ticket for rotation binding
+    const secretHash = HubDB.hashToken(org_secret);
+
+    const isReusable = reusable === true;
+    const ticket = db.createOrgTicket(org.id, secretHash, {
+      reusable: isReusable,
+      expiresAt,
+      createdBy: 'login',
+    });
+
+    res.json({
+      ticket: ticket.id,
+      expires_at: ticket.expires_at,
+      reusable: ticket.reusable,
+      org: { id: org.id, name: org.name },
+    });
+  });
+
+  /**
+   * POST /api/auth/register — Register an agent using a ticket (no Bearer auth needed)
+   * Body: { org_id, ticket, name, display_name?, ...profile fields }
+   * Returns: { agent_id, token, name, auth_role }
+   */
+  router.post('/api/auth/register', async (req, res) => {
+    const { org_id, ticket: ticketId } = req.body;
+
+    // Validate required fields
+    if (!org_id || typeof org_id !== 'string') {
+      res.status(400).json({ error: 'org_id is required', code: 'VALIDATION_ERROR' });
+      return;
+    }
+    if (!ticketId || typeof ticketId !== 'string') {
+      res.status(400).json({ error: 'ticket is required', code: 'VALIDATION_ERROR' });
+      return;
+    }
+
+    // Validate registration body fields
+    const validated = await validateRegistrationBody(req.body, res);
+    if (!validated) return; // response already sent
+
+    // Get and validate the ticket
+    const ticket = db.getOrgTicket(ticketId);
+    if (!ticket) {
+      res.status(401).json({ error: 'Invalid ticket', code: 'INVALID_TICKET' });
+      return;
+    }
+
+    // Check ticket belongs to this org
+    if (ticket.org_id !== org_id) {
+      res.status(401).json({ error: 'Invalid ticket', code: 'INVALID_TICKET' });
+      return;
+    }
+
+    // Check not expired
+    if (ticket.expires_at <= Date.now()) {
+      res.status(401).json({ error: 'Ticket expired', code: 'TICKET_EXPIRED' });
+      return;
+    }
+
+    // Check not already consumed (for one-time tickets)
+    if (!ticket.reusable && ticket.consumed) {
+      res.status(401).json({ error: 'Ticket already consumed', code: 'TICKET_CONSUMED' });
+      return;
+    }
+
+    // Redeem the ticket (atomic consume for one-time tickets)
+    if (!ticket.reusable) {
+      const redeemed = db.redeemOrgTicket(ticketId);
+      if (!redeemed) {
+        res.status(401).json({ error: 'Ticket already consumed', code: 'TICKET_CONSUMED' });
+        return;
+      }
+    }
+
+    // Get org and check status
+    const org = db.getOrgById(org_id);
+    if (!org) {
+      res.status(404).json({ error: 'Organization not found', code: 'NOT_FOUND' });
+      return;
+    }
+    if (org.status !== 'active') {
+      const code = org.status === 'suspended' ? 'ORG_SUSPENDED' : 'ORG_DESTROYED';
+      res.status(403).json({ error: `Organization is ${org.status}`, code });
+      return;
+    }
+
+    // First-agent auto-admin
+    const existingAgents = db.listAgents(org_id);
+    const authRole: 'admin' | 'member' = existingAgents.length === 0 ? 'admin' : 'member';
+
+    // Register the agent
+    const { agent, created, plaintextToken } = db.registerAgent(
+      org_id,
+      validated.name,
+      validated.display_name,
+      validated.metadata,
+      validated.webhook_url,
+      validated.webhook_secret,
+      validated.profile,
+    );
+
+    // Set auth_role (registerAgent defaults to 'member', override if first agent)
+    if (authRole === 'admin' && created) {
+      db.setAgentAuthRole(agent.id, 'admin');
+      agent.auth_role = 'admin';
+    }
+
+    // Audit
+    db.recordAudit(org_id, agent.id, 'bot.register', 'agent', agent.id, { name: agent.name, reregister: !created, via: 'ticket' });
+
+    // Broadcast agent online
+    ws.broadcastToOrg(org_id, {
+      type: 'agent_online',
+      agent: { id: agent.id, name: agent.name, display_name: agent.display_name },
+    });
+
+    const response: Record<string, unknown> = {
+      agent_id: agent.id,
+      ...toAgentResponse(agent),
+    };
+    // Only include token on initial registration
+    if (created && plaintextToken !== null) {
+      response.token = plaintextToken;
+    }
+    res.json(response);
   });
 
   // ─── Authenticated Routes ─────────────────────────────────
@@ -2348,6 +2620,112 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig): Router {
     db.recordAudit(req.org!.id, null, 'settings.update', 'org_settings', req.org!.id, updates);
 
     res.json(settings);
+  });
+
+  // ─── Org Auth Management (Admin Agent) ─────────────────────
+
+  /**
+   * POST /api/org/tickets — Create an org ticket (admin agents only)
+   * Auth: Agent token (admin role)
+   * Body: { reusable?: boolean, expires_in?: number }
+   * Returns: { ticket, expires_at, reusable }
+   */
+  auth.post('/api/org/tickets', requireAgent, requireAuthRole('admin'), (req, res) => {
+    const { reusable, expires_in } = req.body;
+
+    const orgId = req.agent!.org_id;
+    const org = db.getOrgById(orgId);
+    if (!org) {
+      res.status(404).json({ error: 'Organization not found', code: 'NOT_FOUND' });
+      return;
+    }
+
+    // Calculate expiry
+    const expiresInSec = typeof expires_in === 'number' && expires_in > 0 ? expires_in : 1800;
+    const expiresAt = Date.now() + expiresInSec * 1000;
+
+    // Use the org's stored admin_secret hash as the secret_hash for the ticket
+    // This allows rotation invalidation: when admin_secret changes, the hash
+    // won't match new tickets' secret_hash
+    const secretHash = org.admin_secret;
+
+    const isReusable = reusable === true;
+    const ticket = db.createOrgTicket(orgId, secretHash, {
+      reusable: isReusable,
+      expiresAt,
+      createdBy: req.agent!.id,
+    });
+
+    res.json({
+      ticket: ticket.id,
+      expires_at: ticket.expires_at,
+      reusable: ticket.reusable,
+    });
+  });
+
+  /**
+   * POST /api/org/rotate-secret — Rotate the org secret (admin agents only)
+   * Auth: Agent token (admin role)
+   * Returns: { org_secret }
+   */
+  auth.post('/api/org/rotate-secret', requireAgent, requireAuthRole('admin'), (req, res) => {
+    const orgId = req.agent!.org_id;
+    const org = db.getOrgById(orgId);
+    if (!org) {
+      res.status(404).json({ error: 'Organization not found', code: 'NOT_FOUND' });
+      return;
+    }
+
+    // Generate new secret
+    const newSecret = crypto.randomBytes(24).toString('hex');
+    const newSecretHash = HubDB.hashToken(newSecret);
+
+    // Update in DB
+    db.rotateOrgSecret(orgId, newSecretHash);
+
+    // Invalidate all unredeemed org_tickets for this org
+    db.invalidateOrgTickets(orgId);
+
+    res.json({ org_secret: newSecret });
+  });
+
+  /**
+   * PATCH /api/org/agents/:agent_id/role — Update an agent's auth_role (admin agents only)
+   * Auth: Agent token (admin role)
+   * Body: { auth_role: 'admin' | 'member' }
+   * Returns: { agent_id, auth_role }
+   */
+  auth.patch('/api/org/agents/:agent_id/role', requireAgent, requireAuthRole('admin'), (req, res) => {
+    const { auth_role } = req.body;
+
+    // Validate auth_role
+    if (auth_role !== 'admin' && auth_role !== 'member') {
+      res.status(400).json({ error: "auth_role must be 'admin' or 'member'", code: 'VALIDATION_ERROR' });
+      return;
+    }
+
+    const targetAgentId = req.params.agent_id as string;
+    const targetAgent = db.getAgentById(targetAgentId);
+    if (!targetAgent) {
+      res.status(404).json({ error: 'Agent not found', code: 'NOT_FOUND' });
+      return;
+    }
+
+    // Verify same org
+    if (targetAgent.org_id !== req.agent!.org_id) {
+      res.status(404).json({ error: 'Agent not found', code: 'NOT_FOUND' });
+      return;
+    }
+
+    // Guard: admin cannot demote self (prevent lockout)
+    if (targetAgentId === req.agent!.id && auth_role === 'member') {
+      res.status(400).json({ error: 'Cannot demote yourself', code: 'SELF_DEMOTION' });
+      return;
+    }
+
+    db.setAgentAuthRole(targetAgentId, auth_role);
+
+    res.json({ agent_id: targetAgentId, auth_role });
   });
 
   // ─── WS Ticket Exchange ──────────────────────────────────

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -21,8 +21,8 @@ export interface TestEnv {
   config: HubConfig;
   baseUrl: string;
   dataDir: string;
-  /** Create an org and return { orgId, apiKey } */
-  createOrg(name?: string): { id: string; api_key: string };
+  /** Create an org and return { id, api_key, admin_secret } */
+  createOrg(name?: string): { id: string; api_key: string; admin_secret: string };
   /** Register an agent in an org and return { agent, token } */
   registerAgent(apiKey: string, name: string, opts?: Record<string, unknown>): Promise<{ agent: any; token: string }>;
   /** Cleanup — close server, remove temp dir */
@@ -88,7 +88,7 @@ export async function createTestEnv(configOverrides?: Partial<HubConfig>): Promi
   function createOrg(name?: string) {
     const orgName = name || `test-org-${++counter}`;
     const org = db.createOrg(orgName, config.default_persist);
-    return { id: org.id, api_key: org.api_key };
+    return { id: org.id, api_key: org.api_key, admin_secret: org.admin_secret };
   }
 
   async function registerAgent(apiKey: string, agentName: string, opts?: Record<string, unknown>) {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -839,3 +839,434 @@ describe('Health Endpoint', () => {
     expect(res.status).toBe(200);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 2: Ticket-Based Auth, Role Enforcement
+// ═══════════════════════════════════════════════════════════════
+
+describe('Phase 2: Auth Login', () => {
+  let env: TestEnv;
+  let orgId: string;
+  let orgSecret: string;
+
+  beforeAll(async () => {
+    env = await createTestEnv();
+    const org = env.createOrg('login-org');
+    orgId = org.id;
+    orgSecret = org.admin_secret;
+  });
+
+  afterAll(() => env.cleanup());
+
+  it('issues a ticket on valid login', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+    expect(status).toBe(200);
+    expect(body.ticket).toBeTypeOf('string');
+    expect(body.expires_at).toBeTypeOf('number');
+    expect(body.reusable).toBe(false);
+    expect(body.org.id).toBe(orgId);
+    expect(body.org.name).toBe('login-org');
+  });
+
+  it('issues a reusable ticket', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret, reusable: true, expires_in: 3600 },
+    });
+    expect(status).toBe(200);
+    expect(body.reusable).toBe(true);
+    expect(body.expires_at).toBeGreaterThan(Date.now() + 3500 * 1000);
+  });
+
+  it('rejects wrong org_secret', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: 'wrong-secret' },
+    });
+    expect(status).toBe(401);
+    expect(body.code).toBe('INVALID_SECRET');
+  });
+
+  it('rejects unknown org_id', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: 'nonexistent', org_secret: orgSecret },
+    });
+    expect(status).toBe(404);
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  it('rejects missing fields', async () => {
+    const { status: s1 } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_secret: orgSecret },
+    });
+    expect(s1).toBe(400);
+
+    const { status: s2 } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId },
+    });
+    expect(s2).toBe(400);
+  });
+});
+
+describe('Phase 2: Ticket-Based Registration', () => {
+  let env: TestEnv;
+  let orgId: string;
+  let orgSecret: string;
+  let orgKey: string;
+
+  beforeAll(async () => {
+    env = await createTestEnv();
+    const org = env.createOrg('ticket-reg-org');
+    orgId = org.id;
+    orgSecret = org.admin_secret;
+    orgKey = org.api_key;
+  });
+
+  afterAll(() => env.cleanup());
+
+  it('first agent via ticket gets admin role', async () => {
+    // Login to get a ticket
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+
+    // Register via ticket
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'first-agent' },
+    });
+    expect(status).toBe(200);
+    expect(body.agent_id).toBeTypeOf('string');
+    expect(body.token).toBeTypeOf('string');
+    expect(body.name).toBe('first-agent');
+    expect(body.auth_role).toBe('admin');
+  });
+
+  it('second agent via ticket gets member role', async () => {
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'second-agent' },
+    });
+    expect(status).toBe(200);
+    expect(body.auth_role).toBe('member');
+  });
+
+  it('one-time ticket cannot be reused', async () => {
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret, reusable: false },
+    });
+
+    // First use — succeeds
+    const { status: s1 } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'onetime-agent-1' },
+    });
+    expect(s1).toBe(200);
+
+    // Second use — fails
+    const { status: s2, body: b2 } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'onetime-agent-2' },
+    });
+    expect(s2).toBe(401);
+    expect(b2.code).toBe('TICKET_CONSUMED');
+  });
+
+  it('reusable ticket can be used multiple times', async () => {
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret, reusable: true },
+    });
+
+    const { status: s1 } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'reusable-agent-1' },
+    });
+    expect(s1).toBe(200);
+
+    const { status: s2 } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'reusable-agent-2' },
+    });
+    expect(s2).toBe(200);
+  });
+
+  it('rejects invalid ticket', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: 'nonexistent-ticket', name: 'bad-ticket-agent' },
+    });
+    expect(status).toBe(401);
+    expect(body.code).toBe('INVALID_TICKET');
+  });
+
+  it('rejects ticket from wrong org', async () => {
+    const otherOrg = env.createOrg('other-org');
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: otherOrg.id, org_secret: otherOrg.admin_secret },
+    });
+
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'cross-org-agent' },
+    });
+    expect(status).toBe(401);
+    expect(body.code).toBe('INVALID_TICKET');
+  });
+
+  it('legacy registration with org API key still works', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/register', {
+      token: orgKey,
+      body: { name: 'legacy-agent' },
+    });
+    expect(status).toBe(200);
+    expect(body.name).toBe('legacy-agent');
+    expect(body.token).toBeTypeOf('string');
+  });
+
+  it('rejects missing required fields in ticket registration', async () => {
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+
+    // Missing name
+    const { status: s1 } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket },
+    });
+    expect(s1).toBe(400);
+
+    // Missing org_id
+    const { status: s2 } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { ticket: loginBody.ticket, name: 'no-org-agent' },
+    });
+    expect(s2).toBe(400);
+  });
+});
+
+describe('Phase 2: toAgentResponse includes auth_role', () => {
+  let env: TestEnv;
+  let orgKey: string;
+  let agentToken: string;
+
+  beforeAll(async () => {
+    env = await createTestEnv();
+    const org = env.createOrg();
+    orgKey = org.api_key;
+    const { token } = await env.registerAgent(orgKey, 'role-agent');
+    agentToken = token;
+  });
+
+  afterAll(() => env.cleanup());
+
+  it('GET /api/me includes auth_role', async () => {
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/me', { token: agentToken });
+    expect(status).toBe(200);
+    expect(body.auth_role).toBeDefined();
+  });
+
+  it('GET /api/agents includes auth_role in list', async () => {
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/agents', { token: orgKey });
+    expect(status).toBe(200);
+    expect(body[0].auth_role).toBeDefined();
+  });
+});
+
+describe('Phase 2: Role Enforcement & Management', () => {
+  let env: TestEnv;
+  let orgId: string;
+  let orgSecret: string;
+  let adminToken: string;
+  let adminId: string;
+  let memberToken: string;
+  let memberId: string;
+
+  beforeAll(async () => {
+    env = await createTestEnv();
+    const org = env.createOrg('role-org');
+    orgId = org.id;
+    orgSecret = org.admin_secret;
+
+    // Create admin agent (first via ticket = auto-admin)
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+    const { body: adminBody } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'admin-agent' },
+    });
+    adminToken = adminBody.token;
+    adminId = adminBody.agent_id;
+
+    // Create member agent (second = member)
+    const { body: loginBody2 } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+    const { body: memberBody } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody2.ticket, name: 'member-agent' },
+    });
+    memberToken = memberBody.token;
+    memberId = memberBody.agent_id;
+  });
+
+  afterAll(() => env.cleanup());
+
+  it('admin can create tickets via /api/org/tickets', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/org/tickets', {
+      token: adminToken,
+      body: { reusable: true, expires_in: 7200 },
+    });
+    expect(status).toBe(200);
+    expect(body.ticket).toBeTypeOf('string');
+    expect(body.reusable).toBe(true);
+    expect(body.expires_at).toBeGreaterThan(Date.now());
+  });
+
+  it('member cannot create tickets', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/org/tickets', {
+      token: memberToken,
+      body: {},
+    });
+    expect(status).toBe(403);
+    expect(body.code).toBe('FORBIDDEN');
+  });
+
+  it('admin can promote member to admin', async () => {
+    const { status, body } = await api(env.baseUrl, 'PATCH', `/api/org/agents/${memberId}/role`, {
+      token: adminToken,
+      body: { auth_role: 'admin' },
+    });
+    expect(status).toBe(200);
+    expect(body.agent_id).toBe(memberId);
+    expect(body.auth_role).toBe('admin');
+  });
+
+  it('admin can demote other admin to member', async () => {
+    // First promote memberId to admin (may already be from previous test)
+    await api(env.baseUrl, 'PATCH', `/api/org/agents/${memberId}/role`, {
+      token: adminToken,
+      body: { auth_role: 'admin' },
+    });
+
+    // Now demote
+    const { status, body } = await api(env.baseUrl, 'PATCH', `/api/org/agents/${memberId}/role`, {
+      token: adminToken,
+      body: { auth_role: 'member' },
+    });
+    expect(status).toBe(200);
+    expect(body.auth_role).toBe('member');
+  });
+
+  it('admin cannot demote self', async () => {
+    const { status, body } = await api(env.baseUrl, 'PATCH', `/api/org/agents/${adminId}/role`, {
+      token: adminToken,
+      body: { auth_role: 'member' },
+    });
+    expect(status).toBe(400);
+    expect(body.code).toBe('SELF_DEMOTION');
+  });
+
+  it('member cannot change roles', async () => {
+    const { status } = await api(env.baseUrl, 'PATCH', `/api/org/agents/${adminId}/role`, {
+      token: memberToken,
+      body: { auth_role: 'member' },
+    });
+    expect(status).toBe(403);
+  });
+
+  it('rejects invalid auth_role value', async () => {
+    const { status } = await api(env.baseUrl, 'PATCH', `/api/org/agents/${memberId}/role`, {
+      token: adminToken,
+      body: { auth_role: 'superadmin' },
+    });
+    expect(status).toBe(400);
+  });
+});
+
+describe('Phase 2: Org Secret Rotation', () => {
+  let env: TestEnv;
+  let orgId: string;
+  let orgSecret: string;
+  let adminToken: string;
+  let memberToken: string;
+
+  beforeAll(async () => {
+    env = await createTestEnv();
+    const org = env.createOrg('rotate-org');
+    orgId = org.id;
+    orgSecret = org.admin_secret;
+
+    // Create admin agent
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+    const { body: adminBody } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody.ticket, name: 'rotate-admin' },
+    });
+    adminToken = adminBody.token;
+
+    // Create member agent
+    const { body: loginBody2 } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+    const { body: memberBody } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: loginBody2.ticket, name: 'rotate-member' },
+    });
+    memberToken = memberBody.token;
+  });
+
+  afterAll(() => env.cleanup());
+
+  it('admin can rotate org secret', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/org/rotate-secret', {
+      token: adminToken,
+    });
+    expect(status).toBe(200);
+    expect(body.org_secret).toBeTypeOf('string');
+    expect(body.org_secret).toHaveLength(48); // 24 bytes hex
+  });
+
+  it('new secret works for login after rotation', async () => {
+    // Rotate
+    const { body: rotateBody } = await api(env.baseUrl, 'POST', '/api/org/rotate-secret', {
+      token: adminToken,
+    });
+    const newSecret = rotateBody.org_secret;
+
+    // Login with new secret works
+    const { status } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: newSecret },
+    });
+    expect(status).toBe(200);
+
+    // Login with old secret fails
+    const { status: s2 } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: orgSecret },
+    });
+    expect(s2).toBe(401);
+  });
+
+  it('rotation invalidates outstanding tickets', async () => {
+    // Get a new secret first
+    const { body: rotBody } = await api(env.baseUrl, 'POST', '/api/org/rotate-secret', {
+      token: adminToken,
+    });
+
+    // Login to get a ticket with current secret
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: orgId, org_secret: rotBody.org_secret },
+    });
+    const ticketBeforeRotation = loginBody.ticket;
+
+    // Rotate again
+    await api(env.baseUrl, 'POST', '/api/org/rotate-secret', {
+      token: adminToken,
+    });
+
+    // Try to use the old ticket — should fail (tickets were invalidated)
+    const { status } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: orgId, ticket: ticketBeforeRotation, name: 'post-rotation-agent' },
+    });
+    expect(status).toBe(401);
+  });
+
+  it('member cannot rotate secret', async () => {
+    const { status } = await api(env.baseUrl, 'POST', '/api/org/rotate-secret', {
+      token: memberToken,
+    });
+    expect(status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /api/auth/login`: exchange org_id + org_secret for a time-limited ticket
- `POST /api/auth/register`: register agents using tickets (first agent auto-admin)
- `POST /api/org/tickets`: admin agents create tickets for their org
- `POST /api/org/rotate-secret`: admin agents rotate org secret (invalidates tickets)
- `PATCH /api/org/agents/:id/role`: admin promote/demote with self-demotion guard
- `requireAuthRole('admin')` middleware for role-based access control
- `toAgentResponse` now includes `auth_role` field
- Dual-stack: all existing API key flows continue working unchanged

## Phase Context
Phase 2 of 7 in the Org Auth Redesign. Builds on Phase 1 (PR #41).

## Test plan
- [x] TypeScript build clean
- [x] 77 tests pass (51 original + 26 new)
- [x] New test suites: Auth Login (5), Ticket Registration (7), Role Response (2), Role Management (6), Secret Rotation (4)
- [x] Legacy API key registration still works (explicit test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)