### PR TITLE
feat(auth): X-Org-Id header and WS ticket org binding (Phase 3)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -52,6 +52,20 @@ export function authMiddleware(db: HubDB) {
     // Try primary agent token first
     const agent = db.getAgentByToken(token);
     if (agent) {
+      // Phase 3: Validate X-Org-Id header if present
+      const requestedOrgId = req.headers['x-org-id'] as string | undefined;
+      if (requestedOrgId) {
+        if (requestedOrgId !== agent.org_id) {
+          res.status(403).json({
+            error: 'Agent does not belong to the requested organization',
+            code: 'ORG_MISMATCH',
+          });
+          return;
+        }
+      }
+      // No X-Org-Id header — fall back to agent's DB org (single-org compat)
+      // In Phase 7 this will become a deprecation warning
+
       req.agent = agent;
       req.org = db.getOrgById(agent.org_id);
       req.authType = 'agent';
@@ -73,6 +87,18 @@ export function authMiddleware(db: HubDB) {
       }
       const scopedAgent = db.getAgentById(scopedToken.agent_id);
       if (scopedAgent) {
+        // Phase 3: Validate X-Org-Id header if present
+        const requestedOrgId = req.headers['x-org-id'] as string | undefined;
+        if (requestedOrgId) {
+          if (requestedOrgId !== scopedAgent.org_id) {
+            res.status(403).json({
+              error: 'Agent does not belong to the requested organization',
+              code: 'ORG_MISMATCH',
+            });
+            return;
+          }
+        }
+
         req.agent = scopedAgent;
         req.org = db.getOrgById(scopedAgent.org_id);
         req.authType = 'agent';

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2756,7 +2756,9 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig): Router {
       }
       // Invalid admin secret is silently discarded — verified at WS connect time anyway
     }
-    const ticketId = issueWsTicket(token, verifiedAdminSecret);
+    // Phase 3: Include org context in the ticket for WS org binding
+    const orgId = req.agent?.org_id || req.org?.id;
+    const ticketId = issueWsTicket(token, verifiedAdminSecret, orgId);
 
     res.json({
       ticket: ticketId,

--- a/src/ws-tickets.ts
+++ b/src/ws-tickets.ts
@@ -9,6 +9,8 @@ export interface WsTicket {
   token: string;
   /** Optional admin secret (for org-level WS connections) */
   adminSecret?: string;
+  /** Org binding for multi-org validation (Phase 3) */
+  orgId?: string;
   /** Epoch ms when this ticket expires (30s TTL) */
   expiresAt: number;
 }
@@ -32,7 +34,7 @@ function purgeExpiredTickets() {
  * Issue a one-time WS ticket for the given token.
  * Returns the ticket ID (to be used as ?ticket=xxx).
  */
-export function issueWsTicket(token: string, adminSecret?: string): string {
+export function issueWsTicket(token: string, adminSecret?: string, orgId?: string): string {
   purgeExpiredTickets();
   const ticketId = crypto.randomBytes(24).toString('hex');
   wsTicketStore.set(ticketId, {
@@ -40,6 +42,7 @@ export function issueWsTicket(token: string, adminSecret?: string): string {
     // Only store non-empty adminSecret; falsy values (empty string, undefined) are omitted.
     // ws.ts relies on this: ticketAdminSecret || url.searchParams.get('admin') uses JS falsy semantics.
     ...(adminSecret ? { adminSecret } : {}),
+    ...(orgId ? { orgId } : {}),
     expiresAt: Date.now() + WS_TICKET_TTL_MS,
   });
   return ticketId;

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -4,7 +4,7 @@ import type { HubDB } from './db.js';
 import type { WebhookManager } from './webhook.js';
 import { validateParts, type HubConfig, type Message, type MessagePart, type WireMessage, type WsServerEvent } from './types.js';
 import { URL } from 'node:url';
-import { redeemWsTicket } from './ws-tickets.js';
+import { redeemWsTicket, type WsTicket } from './ws-tickets.js';
 import { wsLogger } from './logger.js';
 
 interface WsClient {
@@ -74,16 +74,17 @@ export class HubWS {
       let token: string | null = null;
 
       let ticketAdminSecret: string | undefined;
+      let redeemedTicket: WsTicket | undefined;
 
       if (ticketParam) {
         // Preferred: one-time ticket exchange
-        const ticket = redeemWsTicket(ticketParam);
-        if (!ticket) {
+        redeemedTicket = redeemWsTicket(ticketParam);
+        if (!redeemedTicket) {
           ws.close(4001, 'Invalid or expired ticket');
           return;
         }
-        token = ticket.token;
-        ticketAdminSecret = ticket.adminSecret;
+        token = redeemedTicket.token;
+        ticketAdminSecret = redeemedTicket.adminSecret;
       } else if (tokenParam) {
         // Backward compat: direct token in URL (deprecated — logs a warning)
         wsLogger.warn('Deprecation: WS connection using ?token= in URL. Use POST /api/ws-ticket instead.');
@@ -96,6 +97,12 @@ export class HubWS {
       // Authenticate as agent via primary token
       const agent = db.getAgentByToken(token);
       if (agent) {
+        // Phase 3: Validate org binding if ticket specifies an orgId
+        if (redeemedTicket?.orgId && redeemedTicket.orgId !== agent.org_id) {
+          ws.close(4003, 'Agent does not belong to ticket org');
+          return;
+        }
+
         const client: WsClient = {
           ws,
           agentId: agent.id,
@@ -133,6 +140,12 @@ export class HubWS {
         }
         const scopedAgent = db.getAgentById(scopedToken.agent_id);
         if (scopedAgent) {
+          // Phase 3: Validate org binding if ticket specifies an orgId
+          if (redeemedTicket?.orgId && redeemedTicket.orgId !== scopedAgent.org_id) {
+            ws.close(4003, 'Agent does not belong to ticket org');
+            return;
+          }
+
           const client: WsClient = {
             ws,
             agentId: scopedAgent.id,
@@ -168,6 +181,12 @@ export class HubWS {
       // Try org key + org admin secret (for web UI / human admins)
       const org = db.getOrgByKey(token);
       if (org) {
+        // Phase 3: Validate org binding if ticket specifies an orgId
+        if (redeemedTicket?.orgId && redeemedTicket.orgId !== org.id) {
+          ws.close(4003, 'Token does not belong to ticket org');
+          return;
+        }
+
         // Require org-scoped admin secret (from ticket or deprecated URL param)
         const adminUrlParam = url.searchParams.get('admin');
         if (adminUrlParam && !ticketAdminSecret) {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1270,3 +1270,119 @@ describe('Phase 2: Org Secret Rotation', () => {
     expect(status).toBe(403);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 3: Multi-Org Context (X-Org-Id Header & WS Ticket Org Binding)
+// ═══════════════════════════════════════════════════════════════
+
+describe('Phase 3: X-Org-Id Header Validation', () => {
+  let env: TestEnv;
+  let orgId: string;
+  let agentToken: string;
+
+  beforeAll(async () => {
+    env = await createTestEnv();
+    const org = env.createOrg();
+    orgId = org.id;
+    const { token } = await env.registerAgent(org.api_key, 'org-header-agent');
+    agentToken = token;
+  });
+
+  afterAll(() => env.cleanup());
+
+  it('accepts X-Org-Id matching agent org', async () => {
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+      headers: { 'X-Org-Id': orgId },
+    });
+    expect(status).toBe(200);
+    expect(body.org_id).toBe(orgId);
+  });
+
+  it('rejects X-Org-Id not matching agent org', async () => {
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+      headers: { 'X-Org-Id': 'wrong-org-id-00000000' },
+    });
+    expect(status).toBe(403);
+    expect(body.code).toBe('ORG_MISMATCH');
+  });
+
+  it('works without X-Org-Id (backward compat)', async () => {
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+    });
+    expect(status).toBe(200);
+    expect(body.org_id).toBe(orgId);
+  });
+
+  it('rejects X-Org-Id for scoped token with wrong org', async () => {
+    // Create a scoped token
+    const { body: tokenBody } = await api(env.baseUrl, 'POST', '/api/me/tokens', {
+      token: agentToken,
+      body: { label: 'scoped-org-test', scopes: ['read'] },
+    });
+    expect(tokenBody.token).toBeTruthy();
+
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: tokenBody.token,
+      headers: { 'X-Org-Id': 'wrong-org-id-00000000' },
+    });
+    expect(status).toBe(403);
+    expect(body.code).toBe('ORG_MISMATCH');
+  });
+
+  it('accepts X-Org-Id for scoped token with correct org', async () => {
+    const { body: tokenBody } = await api(env.baseUrl, 'POST', '/api/me/tokens', {
+      token: agentToken,
+      body: { label: 'scoped-org-test-ok', scopes: ['read'] },
+    });
+
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: tokenBody.token,
+      headers: { 'X-Org-Id': orgId },
+    });
+    expect(status).toBe(200);
+    expect(body.org_id).toBe(orgId);
+  });
+});
+
+describe('Phase 3: WS Ticket Org Binding', () => {
+  let env: TestEnv;
+  let orgId: string;
+  let agentToken: string;
+
+  beforeAll(async () => {
+    env = await createTestEnv();
+    const org = env.createOrg();
+    orgId = org.id;
+    const { token } = await env.registerAgent(org.api_key, 'ws-org-agent');
+    agentToken = token;
+  });
+
+  afterAll(() => env.cleanup());
+
+  it('ws-ticket includes org binding and WS connection succeeds', async () => {
+    // Get a ws-ticket (should include org binding)
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/ws-ticket', {
+      token: agentToken,
+    });
+    expect(status).toBe(200);
+    expect(body.ticket).toBeTruthy();
+    expect(body.expires_in).toBe(30);
+
+    // Connect via WS using the ticket
+    const wsUrl = env.baseUrl.replace('http', 'ws');
+    const ws = await new Promise<import('ws').WebSocket>((resolve, reject) => {
+      const { WebSocket } = require('ws');
+      const socket = new WebSocket(`${wsUrl}/ws?ticket=${body.ticket}`);
+      socket.on('open', () => resolve(socket));
+      socket.on('error', reject);
+      setTimeout(() => reject(new Error('WS connect timeout')), 3000);
+    });
+
+    // Connection succeeded — org binding was valid
+    expect(ws.readyState).toBe(1); // OPEN
+    ws.close();
+  });
+});


### PR DESCRIPTION
## Summary
- X-Org-Id header validation in authMiddleware (both primary and scoped token paths)
- WS ticket now carries org binding (`orgId` field)
- WS connection auth validates ticket org against authenticated entity
- Backward compatible: header optional, fallback to agent's DB org

## Phase Context
Phase 3 of 7 in the Org Auth Redesign. Builds on Phase 2 (PR #42).

## Test plan
- [x] TypeScript build clean
- [x] 83 tests pass (77 existing + 6 new)
- [x] X-Org-Id: correct org accepted, wrong org rejected (ORG_MISMATCH), backward compat
- [x] WS ticket org binding round-trip test

🤖 Generated with [Claude Code](https://claude.com/claude-code)