### PR TITLE
feat(admin): org lifecycle — suspend, destroy, status enforcement (Phase 4)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -56,6 +56,17 @@ export function authMiddleware(db: HubDB) {
       req.org = db.getOrgById(agent.org_id);
       req.authType = 'agent';
       req.tokenScopes = ['full'];
+      // Check org status
+      if (req.org) {
+        if (req.org.status === 'suspended') {
+          res.status(403).json({ error: 'Organization is suspended', code: 'ORG_SUSPENDED' });
+          return;
+        }
+        if (req.org.status === 'destroyed') {
+          res.status(403).json({ error: 'Organization is destroyed', code: 'ORG_DESTROYED' });
+          return;
+        }
+      }
       // W3: HTTP requests update last_seen but do NOT mark agent online.
       // Online status is managed exclusively by WS connections.
       db.touchAgentLastSeen(agent.id);
@@ -78,6 +89,17 @@ export function authMiddleware(db: HubDB) {
         req.authType = 'agent';
         req.tokenScopes = scopedToken.scopes;
         req.scopedTokenId = scopedToken.id;
+        // Check org status
+        if (req.org) {
+          if (req.org.status === 'suspended') {
+            res.status(403).json({ error: 'Organization is suspended', code: 'ORG_SUSPENDED' });
+            return;
+          }
+          if (req.org.status === 'destroyed') {
+            res.status(403).json({ error: 'Organization is destroyed', code: 'ORG_DESTROYED' });
+            return;
+          }
+        }
         // W3: HTTP requests update last_seen but do NOT mark agent online.
         db.touchAgentLastSeen(scopedAgent.id);
         db.touchAgentToken(scopedToken.id);
@@ -89,6 +111,15 @@ export function authMiddleware(db: HubDB) {
     // Try org API key
     const org = db.getOrgByKey(token);
     if (org) {
+      // Check org status
+      if (org.status === 'suspended') {
+        res.status(403).json({ error: 'Organization is suspended', code: 'ORG_SUSPENDED' });
+        return;
+      }
+      if (org.status === 'destroyed') {
+        res.status(403).json({ error: 'Organization is destroyed', code: 'ORG_DESTROYED' });
+        return;
+      }
       req.org = org;
       req.authType = 'org';
       next();

--- a/src/db.ts
+++ b/src/db.ts
@@ -794,6 +794,21 @@ export class HubDB {
     return (this.db.prepare('SELECT * FROM orgs ORDER BY created_at').all() as any[]).map(r => this.rowToOrg(r));
   }
 
+  updateOrgStatus(orgId: string, status: 'active' | 'suspended'): void {
+    this.db.prepare('UPDATE orgs SET status = ? WHERE id = ?').run(status, orgId);
+  }
+
+  updateOrgName(orgId: string, name: string): void {
+    this.db.prepare('UPDATE orgs SET name = ? WHERE id = ?').run(name, orgId);
+  }
+
+  destroyOrg(orgId: string): void {
+    // Set status first (for any in-flight requests to see)
+    this.db.prepare("UPDATE orgs SET status = 'destroyed' WHERE id = ?").run(orgId);
+    // CASCADE delete handles all related data (agents, channels, threads, etc.)
+    this.db.prepare('DELETE FROM orgs WHERE id = ?').run(orgId);
+  }
+
   // ─── Org Ticket Operations ─────────────────────────────
 
   private rowToOrgTicket(row: any): OrgTicket {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -280,8 +280,8 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig): Router {
       return;
     }
     const org = db.createOrg(name, persist_messages ?? config.default_persist);
-    const { admin_secret: _stripped, ...safeOrg } = org;
-    res.json(safeOrg);
+    // Return full org including admin_secret for super admin
+    res.json(org);
   });
 
   /**
@@ -290,8 +290,86 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig): Router {
    */
   router.get('/api/orgs', (req, res) => {
     if (!requireAdmin(req, res)) return;
-    const orgs = db.listOrgs().map(({ api_key, admin_secret, ...safe }) => safe);
+    const orgs = db.listOrgs().map(({ api_key, admin_secret, ...safe }) => ({
+      ...safe,
+      agent_count: db.listAgents(safe.id).length,
+    }));
     res.json(orgs);
+  });
+
+  /**
+   * PATCH /api/orgs/:org_id — Update org name or status
+   * Auth: Super admin (BOTSHUB_ADMIN_SECRET)
+   * Body: { name?: string, status?: 'active' | 'suspended' }
+   */
+  router.patch('/api/orgs/:org_id', (req, res) => {
+    if (!requireAdmin(req, res)) return;
+
+    const org = db.getOrgById(req.params.org_id);
+    if (!org) {
+      res.status(404).json({ error: 'Organization not found', code: 'NOT_FOUND' });
+      return;
+    }
+
+    if (org.status === 'destroyed') {
+      res.status(409).json({ error: 'Cannot modify destroyed org', code: 'ORG_DESTROYED' });
+      return;
+    }
+
+    const { name, status } = req.body;
+
+    if (status !== undefined) {
+      if (status !== 'active' && status !== 'suspended') {
+        res.status(400).json({ error: 'status must be "active" or "suspended" (use DELETE to destroy)', code: 'VALIDATION_ERROR' });
+        return;
+      }
+
+      if (status !== org.status) {
+        db.updateOrgStatus(org.id, status);
+
+        if (status === 'suspended') {
+          // Invalidate all outstanding org tickets
+          db.invalidateOrgTickets(org.id);
+          // Disconnect all WS clients
+          ws.disconnectOrg(org.id, 4100, 'Organization suspended');
+        }
+      }
+    }
+
+    if (name !== undefined) {
+      if (!name || typeof name !== 'string') {
+        res.status(400).json({ error: 'name must be a non-empty string', code: 'VALIDATION_ERROR' });
+        return;
+      }
+      db.updateOrgName(org.id, name);
+    }
+
+    // Re-fetch to return current state
+    const updated = db.getOrgById(org.id)!;
+    res.json({ id: updated.id, name: updated.name, status: updated.status });
+  });
+
+  /**
+   * DELETE /api/orgs/:org_id — Destroy an org (irreversible)
+   * Auth: Super admin (BOTSHUB_ADMIN_SECRET)
+   * Response: 204 No Content
+   */
+  router.delete('/api/orgs/:org_id', (req, res) => {
+    if (!requireAdmin(req, res)) return;
+
+    const org = db.getOrgById(req.params.org_id);
+    if (!org) {
+      res.status(404).json({ error: 'Organization not found', code: 'NOT_FOUND' });
+      return;
+    }
+
+    // Disconnect all WS clients before deletion
+    ws.disconnectOrg(org.id, 4101, 'Organization destroyed');
+
+    // Destroy org (sets status, then deletes — CASCADE handles related data)
+    db.destroyOrg(org.id);
+
+    res.status(204).end();
   });
 
   // ─── Shared Registration Validation ───────────────────────

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -96,6 +96,13 @@ export class HubWS {
       // Authenticate as agent via primary token
       const agent = db.getAgentByToken(token);
       if (agent) {
+        // Check org status before allowing connection
+        const agentOrg = db.getOrgById(agent.org_id);
+        if (!agentOrg || agentOrg.status !== 'active') {
+          ws.close(4100, 'Organization is not active');
+          return;
+        }
+
         const client: WsClient = {
           ws,
           agentId: agent.id,
@@ -133,6 +140,13 @@ export class HubWS {
         }
         const scopedAgent = db.getAgentById(scopedToken.agent_id);
         if (scopedAgent) {
+          // Check org status before allowing connection
+          const scopedOrg = db.getOrgById(scopedAgent.org_id);
+          if (!scopedOrg || scopedOrg.status !== 'active') {
+            ws.close(4100, 'Organization is not active');
+            return;
+          }
+
           const client: WsClient = {
             ws,
             agentId: scopedAgent.id,
@@ -168,6 +182,12 @@ export class HubWS {
       // Try org key + org admin secret (for web UI / human admins)
       const org = db.getOrgByKey(token);
       if (org) {
+        // Check org status before allowing connection
+        if (org.status !== 'active') {
+          ws.close(4100, 'Organization is not active');
+          return;
+        }
+
         // Require org-scoped admin secret (from ticket or deprecated URL param)
         const adminUrlParam = url.searchParams.get('admin');
         if (adminUrlParam && !ticketAdminSecret) {
@@ -428,6 +448,18 @@ export class HubWS {
   private send(client: WsClient, event: WsServerEvent) {
     if (client.ws.readyState === WebSocket.OPEN) {
       client.ws.send(JSON.stringify(event));
+    }
+  }
+
+  /**
+   * Disconnect all WebSocket clients belonging to a specific org.
+   * Used when org is suspended or destroyed.
+   */
+  disconnectOrg(orgId: string, closeCode: number, reason: string): void {
+    for (const client of [...this.clients]) {
+      if (client.orgId === orgId) {
+        client.ws.close(closeCode, reason);
+      }
     }
   }
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1270,3 +1270,279 @@ describe('Phase 2: Org Secret Rotation', () => {
     expect(status).toBe(403);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 4: Super Admin Org Lifecycle
+// ═══════════════════════════════════════════════════════════════
+
+describe('Phase 4: Super Admin Org Lifecycle', () => {
+  const ADMIN_SECRET = 'test-super-admin-secret';
+  let env: TestEnv;
+
+  beforeAll(async () => {
+    env = await createTestEnv({ admin_secret: ADMIN_SECRET });
+  });
+
+  afterAll(() => env.cleanup());
+
+  it('POST /api/orgs returns admin_secret and status', async () => {
+    const { status, body } = await api(env.baseUrl, 'POST', '/api/orgs', {
+      token: ADMIN_SECRET,
+      body: { name: 'lifecycle-org' },
+    });
+    expect(status).toBe(200);
+    expect(body.name).toBe('lifecycle-org');
+    expect(body.status).toBe('active');
+    expect(body.admin_secret).toBeTypeOf('string');
+    expect(body.api_key).toBeTypeOf('string');
+  });
+
+  it('POST /api/orgs requires admin auth', async () => {
+    const { status } = await api(env.baseUrl, 'POST', '/api/orgs', {
+      token: 'wrong-secret',
+      body: { name: 'should-fail' },
+    });
+    expect(status).toBe(401);
+  });
+
+  it('GET /api/orgs includes status and agent_count', async () => {
+    // Create an org with an agent so we can verify agent_count
+    const org = env.createOrg('list-test-org');
+    await env.registerAgent(org.api_key, 'list-agent');
+
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/orgs', {
+      token: ADMIN_SECRET,
+    });
+    expect(status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    const found = body.find((o: any) => o.name === 'list-test-org');
+    expect(found).toBeDefined();
+    expect(found.status).toBe('active');
+    expect(found.agent_count).toBe(1);
+    // api_key and admin_secret should be stripped from list
+    expect(found.api_key).toBeUndefined();
+    expect(found.admin_secret).toBeUndefined();
+  });
+
+  it('PATCH /api/orgs/:id can update name', async () => {
+    const org = env.createOrg('rename-me');
+
+    const { status, body } = await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { name: 'renamed-org' },
+    });
+    expect(status).toBe(200);
+    expect(body.name).toBe('renamed-org');
+    expect(body.status).toBe('active');
+  });
+
+  it('PATCH /api/orgs/:id can suspend org', async () => {
+    const org = env.createOrg('suspend-me');
+
+    const { status, body } = await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'suspended' },
+    });
+    expect(status).toBe(200);
+    expect(body.status).toBe('suspended');
+  });
+
+  it('PATCH /api/orgs/:id can reactivate suspended org', async () => {
+    const org = env.createOrg('reactivate-me');
+
+    // Suspend
+    await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'suspended' },
+    });
+
+    // Reactivate
+    const { status, body } = await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'active' },
+    });
+    expect(status).toBe(200);
+    expect(body.status).toBe('active');
+  });
+
+  it('PATCH /api/orgs/:id rejects setting status to destroyed', async () => {
+    const org = env.createOrg('no-destroy-patch');
+
+    const { status, body } = await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'destroyed' },
+    });
+    expect(status).toBe(400);
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('PATCH /api/orgs/:id rejects modifying destroyed org', async () => {
+    const org = env.createOrg('destroy-then-patch');
+
+    // Destroy via DELETE
+    await api(env.baseUrl, 'DELETE', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+    });
+
+    // Try to modify — org is gone (deleted from DB)
+    const { status } = await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { name: 'impossible' },
+    });
+    expect(status).toBe(404);
+  });
+
+  it('PATCH /api/orgs/:id returns 404 for unknown org', async () => {
+    const { status } = await api(env.baseUrl, 'PATCH', '/api/orgs/nonexistent-id', {
+      token: ADMIN_SECRET,
+      body: { name: 'nope' },
+    });
+    expect(status).toBe(404);
+  });
+
+  it('DELETE /api/orgs/:id destroys org', async () => {
+    const org = env.createOrg('destroy-me');
+
+    const { status } = await api(env.baseUrl, 'DELETE', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+    });
+    expect(status).toBe(204);
+
+    // Verify org is gone
+    const { status: listStatus, body: orgs } = await api(env.baseUrl, 'GET', '/api/orgs', {
+      token: ADMIN_SECRET,
+    });
+    expect(listStatus).toBe(200);
+    const found = orgs.find((o: any) => o.id === org.id);
+    expect(found).toBeUndefined();
+  });
+
+  it('DELETE /api/orgs/:id returns 404 for unknown org', async () => {
+    const { status } = await api(env.baseUrl, 'DELETE', '/api/orgs/nonexistent-id', {
+      token: ADMIN_SECRET,
+    });
+    expect(status).toBe(404);
+  });
+
+  it('suspended org rejects authenticated API calls', async () => {
+    const org = env.createOrg('suspend-api-test');
+    const { token: agentToken } = await env.registerAgent(org.api_key, 'test-agent');
+
+    // Verify agent can make API calls initially
+    const { status: beforeStatus } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+    });
+    expect(beforeStatus).toBe(200);
+
+    // Suspend org
+    await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'suspended' },
+    });
+
+    // Agent API calls should now be rejected
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+    });
+    expect(status).toBe(403);
+    expect(body.code).toBe('ORG_SUSPENDED');
+  });
+
+  it('reactivated org allows API calls again', async () => {
+    const org = env.createOrg('reactivate-api-test');
+    const { token: agentToken } = await env.registerAgent(org.api_key, 'test-agent');
+
+    // Suspend
+    await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'suspended' },
+    });
+
+    // Verify blocked
+    const { status: blockedStatus } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+    });
+    expect(blockedStatus).toBe(403);
+
+    // Reactivate
+    await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'active' },
+    });
+
+    // API calls should work again
+    const { status } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+    });
+    expect(status).toBe(200);
+  });
+
+  it('suspended org rejects org API key auth too', async () => {
+    const org = env.createOrg('suspend-orgkey-test');
+
+    // Verify org key works initially
+    const { status: beforeStatus } = await api(env.baseUrl, 'GET', '/api/agents', {
+      token: org.api_key,
+    });
+    expect(beforeStatus).toBe(200);
+
+    // Suspend
+    await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'suspended' },
+    });
+
+    // Org key should be rejected
+    const { status, body } = await api(env.baseUrl, 'GET', '/api/agents', {
+      token: org.api_key,
+    });
+    expect(status).toBe(403);
+    expect(body.code).toBe('ORG_SUSPENDED');
+  });
+
+  it('suspension invalidates outstanding org tickets', async () => {
+    const org = env.createOrg('suspend-tickets-test');
+
+    // Login to get a ticket
+    const { body: loginBody } = await api(env.baseUrl, 'POST', '/api/auth/login', {
+      body: { org_id: org.id, org_secret: org.admin_secret },
+    });
+    const ticket = loginBody.ticket;
+    expect(ticket).toBeTypeOf('string');
+
+    // Suspend the org
+    await api(env.baseUrl, 'PATCH', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+      body: { status: 'suspended' },
+    });
+
+    // Ticket should be invalidated
+    const { status } = await api(env.baseUrl, 'POST', '/api/auth/register', {
+      body: { org_id: org.id, ticket, name: 'post-suspend-agent' },
+    });
+    expect(status).toBe(401);
+  });
+
+  it('destroy cascades to agents and channels', async () => {
+    const org = env.createOrg('cascade-test');
+    const { token: agentToken } = await env.registerAgent(org.api_key, 'cascade-agent');
+
+    // Verify agent exists
+    const { status: agentStatus } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+    });
+    expect(agentStatus).toBe(200);
+
+    // Destroy
+    const { status } = await api(env.baseUrl, 'DELETE', `/api/orgs/${org.id}`, {
+      token: ADMIN_SECRET,
+    });
+    expect(status).toBe(204);
+
+    // Agent token should be invalid (org and agents deleted)
+    const { status: afterStatus } = await api(env.baseUrl, 'GET', '/api/me', {
+      token: agentToken,
+    });
+    expect(afterStatus).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- `PATCH /api/orgs/:id`: super admin can update name, suspend/reactivate orgs
- `DELETE /api/orgs/:id`: super admin destroys org (CASCADE delete, 204)
- Status enforcement in authMiddleware: suspended orgs get 403 `ORG_SUSPENDED`
- WS disconnect on suspend (4100) and destroy (4101)
- WS connection gate: reject new connections to non-active orgs
- Suspension invalidates outstanding org tickets
- `POST /api/orgs` now returns admin_secret + status
- `GET /api/orgs` now includes status + agent_count

## Phase Context
Phase 4 of 7 in the Org Auth Redesign. Builds on Phase 2 (PR #42). Parallel with Phase 3 (PR #43).

## Test plan
- [x] TypeScript build clean
- [x] 93 tests pass (77 existing + 16 new)
- [x] Suspend/reactivate/destroy lifecycle tests
- [x] Status enforcement across all auth paths
- [x] Ticket invalidation on suspend
- [x] CASCADE delete verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)