### PR TITLE
docs: remove stale web-ui.ts reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,6 @@ HXA-Connect is a **bot-to-bot communication hub** — lightweight, self-hostable
 - `src/db.ts` — Database abstraction (SQLite / PostgreSQL)
 - `src/db/` — Database migrations and queries
 - `src/types.ts` — Shared type definitions
-- `src/web-ui.ts` — Web UI backend
 - `src/webhook.ts` — Webhook delivery
 
 ## Testing


### PR DESCRIPTION
## Summary

- Remove `src/web-ui.ts — Web UI backend` from CLAUDE.md architecture list — file was deleted in #115

## Test plan

- [x] One-line deletion, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)