### PR TITLE
feat: add GET /api/stats endpoint (#156)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -3020,6 +3020,37 @@ export class HubDB {
     return await this.driver.isHealthy();
   }
 
+  async getPlatformStats(): Promise<{
+    org_count: number;
+    bot_count: number;
+    online_bot_count: number;
+    thread_count: number;
+    message_count: number;
+    active_thread_count: number;
+  }> {
+    const now = Date.now();
+    const onlineThreshold = now - 5 * 60 * 1000; // 5 min
+    const activeThreshold = now - 24 * 60 * 60 * 1000; // 24h
+
+    const [orgs, bots, onlineBots, threads, messages, activeThreads] = await Promise.all([
+      this.driver.get<{ c: number }>('SELECT COUNT(*) AS c FROM orgs', []),
+      this.driver.get<{ c: number }>('SELECT COUNT(*) AS c FROM bots', []),
+      this.driver.get<{ c: number }>('SELECT COUNT(*) AS c FROM bots WHERE last_seen_at > ?', [onlineThreshold]),
+      this.driver.get<{ c: number }>('SELECT COUNT(*) AS c FROM threads', []),
+      this.driver.get<{ c: number }>('SELECT COUNT(*) AS c FROM thread_messages', []),
+      this.driver.get<{ c: number }>('SELECT COUNT(*) AS c FROM threads WHERE last_activity_at > ?', [activeThreshold]),
+    ]);
+
+    return {
+      org_count: Number(orgs?.c ?? 0),
+      bot_count: Number(bots?.c ?? 0),
+      online_bot_count: Number(onlineBots?.c ?? 0),
+      thread_count: Number(threads?.c ?? 0),
+      message_count: Number(messages?.c ?? 0),
+      active_thread_count: Number(activeThreads?.c ?? 0),
+    };
+  }
+
   async close(): Promise<void> {
     await this.driver.close();
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -355,6 +355,26 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig, sessionSto
   });
 
   /**
+   * GET /api/stats — Public platform statistics
+   * Returns aggregate counts (no sensitive data). Cached for 60s.
+   */
+  let statsCache: { data: unknown; expires: number } | null = null;
+  router.get('/api/stats', async (_req, res) => {
+    try {
+      const now = Date.now();
+      if (statsCache && statsCache.expires > now) {
+        return res.json(statsCache.data);
+      }
+      const stats = await db.getPlatformStats();
+      statsCache = { data: stats, expires: now + 60_000 };
+      res.json(stats);
+    } catch (err) {
+      routeLogger.error({ err }, 'stats.error');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
    * POST /api/orgs — Create an organization
    * Body: { name, persist_messages? }
    * Auth: Admin secret (if HXA_CONNECT_ADMIN_SECRET is set)


### PR DESCRIPTION
## Summary
- New public endpoint `GET /api/stats` returning aggregate platform statistics
- Stats: org_count, bot_count, online_bot_count, thread_count, message_count, active_thread_count (24h)
- Response cached in memory (60s TTL) to minimize DB load
- No sensitive data exposed — only aggregate numbers
- Branched from main (clean diff, no PR #155 overlap)

## Changes
- `src/db.ts`: Added `getPlatformStats()` method with 6 parallel COUNT queries
- `src/routes.ts`: Added `/api/stats` route with in-memory cache

## Test plan
- [ ] `GET /api/stats` returns valid JSON with all 6 fields
- [ ] Second request within 60s returns cached result
- [ ] No auth required (public endpoint)
- [ ] TypeScript compiles clean, 358 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)