### PR TITLE
fix: mention picker selects on touch instead of scrolling on mobile (#191)

### DIFF
--- a/web-next/src/components/ui/MentionPopup.tsx
+++ b/web-next/src/components/ui/MentionPopup.tsx
@@ -47,7 +47,12 @@ export function MentionPopup({ candidates, query, selectedIndex, onSelect, onClo
       {filtered.map((c, i) => (
         <button
           key={c.id}
-          onPointerDown={(e) => { e.preventDefault(); onSelect(c.name); }}
+          // Prevent the textarea from losing focus on mouse click (desktop only).
+          // Do NOT use onPointerDown/onTouchStart for selection — those fire before
+          // the browser can distinguish a tap from a scroll, making the list
+          // impossible to scroll on touch devices (issue #191).
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => onSelect(c.name)}
           onMouseEnter={() => onHover?.(i)}
           className={cn(
             'w-full text-left px-3 py-2.5 sm:py-1.5 text-sm flex items-center gap-2 transition-colors',


### PR DESCRIPTION
## Problem

On mobile devices, the `@mention` dropdown in Thread chat immediately selects an item on `touchstart`, making it impossible to scroll through the candidate list.

**Root cause:** The button used `onPointerDown` to trigger selection. `onPointerDown` fires as soon as the finger touches the screen — before the browser can determine whether the gesture is a tap or a scroll — so every touch immediately selected the first item under the finger.

## Fix

Replace `onPointerDown` with two separate handlers:

- `onMouseDown={(e) => e.preventDefault()}` — desktop only; prevents the textarea from losing focus when clicking a candidate (unchanged behavior)
- `onClick={() => onSelect(c.name)}` — fires only after a complete tap (touchstart + touchend with no significant movement); a scroll gesture suppresses the `click` event naturally

This is the standard pattern for interactive list items that must not steal focus from a nearby input.

## Behavior

| Gesture | Before | After |
|---------|--------|-------|
| Mobile tap | ✅ selects | ✅ selects |
| Mobile swipe/scroll | ❌ selects (wrong) | ✅ scrolls |
| Desktop click | ✅ selects (no blur) | ✅ selects (no blur) |
| Keyboard nav | ✅ works | ✅ works |

## Files Changed

- `web-next/src/components/ui/MentionPopup.tsx` — 1 line changed, comment added

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)