### PR TITLE
chore: bump version to 1.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.4.8] - 2026-03-14
+
+### Added
+- **Session/ticket management endpoints**: GET and DELETE endpoints for session and ticket management (#114)
+- **Multi-repo development spec**: Cross-repo coordination rules, version compatibility declarations, and recommended release order (#216, #217)
+
+### Fixed
+- **Hierarchical org-isolated file storage**: Migrate from flat `files/<uuid>` to `files/<org>/<uploader>/<shard>/<uuid>.ext` layout with temp staging, startup cleanup, and migration script (#212, #214)
+- **Bot security hardening**: Prevent delete+re-register identity hijack via bot name tombstone; fix registerBot() TOCTOU race; harden renameBot() transaction; unify sentinel pattern in atomicRegisterBotWithTicket (#199, #178)
+- **Session endpoint hardening**: orgId validation, HMAC key enforcement, pagination for session scanning (#207)
+- **IME Enter handling**: Fix double-submit on CJK IME composition in thread chat; add @mention highlighting (#209)
+- **Mention picker mobile touch**: Fix touch event selecting wrong item on mobile scroll (#191)
+
+### Docs
+- Remove zylos-hxa-connect repo link from Platform integrations (#205, #206)
+
 ## [1.4.7] - 2026-03-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hxa-connect",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hxa-connect",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "better-sqlite3": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hxa-connect",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Bot-to-Bot Communication Hub — lightweight, self-hostable messaging infrastructure for AI bots",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump version 1.4.7 → 1.4.8
- Update CHANGELOG.md with all changes since v1.4.7

### Changes included in v1.4.8

**Added:**
- Session/ticket management endpoints (#114)
- Multi-repo development spec (#216, #217)

**Fixed:**
- Hierarchical org-isolated file storage (#212, #214)
- Bot security hardening — tombstone, TOCTOU, identity hijack (#199, #178)
- Session endpoint hardening (#207)
- IME Enter handling + @mention highlighting (#209)
- Mention picker mobile touch (#191)

**Docs:**
- Remove zylos-hxa-connect repo link (#205, #206)

## Test plan

- [x] `npm test` — 418 passed, 1 pre-existing web-ui skip (missing static build)
- [ ] After merge: create GitHub Release with tag `v1.4.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)