### PR TITLE
feat: implicit reply mention (#219)

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -197,14 +197,17 @@ export async function buildReplyContext(db: any, msg: ThreadMessage): Promise<Re
  * Inject an implicit mention for the sender of the replied-to message.
  * When a message has reply_to and the parent message has a sender,
  * that sender is added to mentions (if not already present).
+ * Skips when the current sender is replying to their own message.
  * This enables "reply = implicit @mention" behavior (issue #219).
  */
 export async function injectReplyMention(
   mentions: MentionRef[] | null,
   parentSenderId: string | null | undefined,
+  currentSenderId: string,
   getBotById: (id: string) => Promise<Bot | undefined>,
 ): Promise<MentionRef[] | null> {
   if (!parentSenderId) return mentions;
+  if (parentSenderId === currentSenderId) return mentions;
   const arr = mentions || [];
   if (arr.some(m => m.bot_id === parentSenderId)) return mentions;
   const bot = await getBotById(parentSenderId);
@@ -2853,7 +2856,7 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig, sessionSto
 
     // #219: Implicit mention — reply_to a message implies mentioning its sender
     if (parentMsg) {
-      mentionRefs = await injectReplyMention(mentionRefs, parentMsg.sender_id, async (id) => await db.getBotById(id));
+      mentionRefs = await injectReplyMention(mentionRefs, parentMsg.sender_id, req.bot!.id, async (id) => await db.getBotById(id));
     }
 
     const message = await db.createThreadMessage(

--- a/src/ws/handlers.ts
+++ b/src/ws/handlers.ts
@@ -267,7 +267,7 @@ export async function handleSendThreadMessage(hub: WsHub, client: WsClient, data
       hub.sendError(client, 'reply_to must be a string (message ID)', { ref });
       return;
     }
-    parentMsg = await hub.db.getThreadMessageById(reply_to);
+    parentMsg = await hub.db.getThreadMessageById(reply_to) ?? undefined;
     if (!parentMsg || parentMsg.thread_id !== thread.id) {
       hub.sendError(client, 'reply_to message not found in this thread', { ref, code: 'NOT_FOUND' });
       return;
@@ -283,7 +283,7 @@ export async function handleSendThreadMessage(hub: WsHub, client: WsClient, data
 
   // #219: Implicit mention — reply_to a message implies mentioning its sender
   if (parentMsg) {
-    mentionRefs = await injectReplyMention(mentionRefs, parentMsg.sender_id, (id) => hub.db.getBotById(id));
+    mentionRefs = await injectReplyMention(mentionRefs, parentMsg.sender_id, client.botId!, (id) => hub.db.getBotById(id));
   }
 
   const message = await hub.db.createThreadMessage(

--- a/test/implicit-reply-mention.test.ts
+++ b/test/implicit-reply-mention.test.ts
@@ -87,22 +87,14 @@ describe('Implicit Reply Mention (#219)', () => {
   });
 
   it('reply to own message does NOT self-mention', async () => {
-    // bot1 replies to its own message
     const { status, body } = await api(env.baseUrl, 'POST', `/api/threads/${threadId}/messages`, {
       token: botToken1,
       body: { content: 'follow-up on my own message', reply_to: msgFromBot1 },
     });
 
     expect(status).toBe(200);
-    // bot1 should not appear in mentions (sender == parent sender)
-    // Actually, our implementation DOES add it. Let me reconsider...
-    // The feature is about the connector checking "am I mentioned?" — self-mention
-    // is harmless and can be useful (bot sees it's mentioned, processes it).
-    // But the more natural behavior: the sender already knows they're replying.
-    // Let's verify the actual behavior and document it.
-    expect(body.mentions).toEqual(
-      expect.arrayContaining([{ bot_id: bot1Id, name: 'alpha' }]),
-    );
+    // Sender replying to own message — no implicit mention (you don't @-mention yourself)
+    expect(body.mentions).toEqual([]);
   });
 
   it('message without reply_to has no implicit mentions', async () => {
@@ -204,5 +196,19 @@ describe('Implicit Reply Mention (#219)', () => {
     // bot1 (alpha) should NOT be mentioned (grandparent, only 1 level)
     const alphaRef = chainReply.mentions.find((m: any) => m.bot_id === bot1Id);
     expect(alphaRef).toBeUndefined();
+  });
+
+  it('reply to null-sender message injects no mention', async () => {
+    // Insert a message with null sender_id directly via DB (simulates system message)
+    const sysMsg = await env.db.createThreadMessage(threadId, null as any, 'system notification', 'text');
+
+    const { status, body } = await api(env.baseUrl, 'POST', `/api/threads/${threadId}/messages`, {
+      token: botToken1,
+      body: { content: 'replying to system message', reply_to: sysMsg.id },
+    });
+
+    expect(status).toBe(200);
+    // No implicit mention — parent has no sender
+    expect(body.mentions).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #219 — Thread reply should trigger bot response without @mention.

When a thread message includes `reply_to`, the server automatically adds the parent message's sender to the `mentions` array. This enables bots in "mention mode" to process replies without requiring explicit `@mention`.

### Changes
- **`src/routes.ts`**: Add exported `injectReplyMention()` helper; inject implicit mention in REST `POST /api/threads/:id/messages`
- **`src/ws/handlers.ts`**: Import and inject implicit mention in WebSocket `send_thread_message` handler
- **`test/implicit-reply-mention.test.ts`**: 9 integration tests covering core behavior, deduplication, edge cases, reply chains

### Design
- Shared helper handles: null sender (skip), deleted bot (skip), already mentioned (dedup)
- Injection happens after text-based `parseMentions()`, before `createThreadMessage()` DB insert
- Purely additive — messages without `reply_to` are completely unaffected
- Both REST and WS paths use identical logic

### Test Results
- 427 tests pass (418 existing + 9 new)
- 1 pre-existing failure in `web-ui.test.ts` (static file check, unrelated)

## Test plan
- [x] Integration tests: implicit mention injection via REST API
- [x] Deduplication with explicit @mention
- [x] Reply chain (1-level only, no grandparent mention)
- [x] Edge cases: invalid reply_to, no reply_to, @all + reply
- [x] Wire format verification (GET /messages returns implicit mentions)
- [ ] WebSocket path (WS test coverage TBD, same logic shared via helper)
- [ ] E2E: connector in mention-mode processes reply without @mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)