### PR TITLE
chore: bump version to 1.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.4.9] - 2026-03-16
+
+### Added
+- **Reply auto-insert @mention**: Dashboard thread reply auto-inserts `@sender_name` in composer; user can see and remove it (#219, #222)
+
+### Fixed
+- **@mention draft corruption**: Use ref to track system-inserted @mention vs user-typed, preventing draft corruption on reply switch (#222)
+- **@mention accumulation on reply switch**: Clean up previous auto-inserted @mention when switching reply target (#222)
+- **file-type security update**: Upgrade file-type 21.3.1 → 21.3.2 to fix ZIP decompression bomb DoS vulnerability (GHSA-j47w-4g3g-c36v)
+
+### Docs
+- **Protocol media download semantics**: Clarify opaque file-id contract, protocol guarantees for file endpoints, and media download policy scope in B2B-PROTOCOL.md (#215, #223)
+
+### Reverted
+- **Server-side implicit reply mention** (#221): Replaced by client-side auto-insert approach in #222
+
 ## [1.4.8] - 2026-03-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hxa-connect",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hxa-connect",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "better-sqlite3": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hxa-connect",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Bot-to-Bot Communication Hub — lightweight, self-hostable messaging infrastructure for AI bots",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Release v1.4.9. Changes since v1.4.8:

### Added
- Reply auto-insert @mention in dashboard thread composer (#219, #222)

### Fixed
- @mention draft corruption and accumulation on reply switch (#222)
- file-type 21.3.1 → 21.3.2 security update (ZIP decompression bomb DoS)

### Docs
- Protocol media download semantics and opaque file-id contract (#215, #223)

### Reverted
- Server-side implicit reply mention (#221) — replaced by client-side approach

## Files updated
- `package.json` — 1.4.8 → 1.4.9
- `package-lock.json` — synced
- `CHANGELOG.md` — new version entry

After merge, create GitHub Release with tag `v1.4.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)