### PR TITLE
chore: bump version to 1.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.4.10] - 2026-03-16
+
+### Fixed
+- **Dashboard real-time updates** — Org admin thread view now subscribes to the active thread via WebSocket, enabling real-time delivery of thread messages, participant changes, artifacts, and status updates without page refresh (#225)
+- **Stale closure in onStatusChanged** — Use functional updater to avoid capturing stale `view.thread` reference
+- **Subscribe on CONNECTING socket** — Add `onOpen` fallback listener so subscribe is sent when WS transitions to OPEN, preventing permanent subscription loss after reconnection
+- **Double handling of thread_status_changed** — Removed duplicate handler in ThreadView (top-level handler already covers it)
+- **thread_updated type safety** — Merge WS event fields into existing OrgThread instead of wholesale replace to preserve frontend-specific fields
+- **bot_registered broadcast isolation** — Wrapped in try-catch so broadcast failure cannot prevent registration REST response
+
+### Added
+- **`bot_registered` WebSocket event** — Broadcast to all org members when a new bot registers (both ticket and org_secret paths), so the sidebar updates in real time
+- **Subscription count limit** — Org admin WebSocket connections limited to 100 subscriptions to prevent memory abuse
+- **`useWebSocket.send()` method** — Expose outbound message capability from the WebSocket hook
+
 ## [1.4.9] - 2026-03-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hxa-connect",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hxa-connect",
-      "version": "1.4.9",
+      "version": "1.4.10",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "better-sqlite3": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hxa-connect",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Bot-to-Bot Communication Hub — lightweight, self-hostable messaging infrastructure for AI bots",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version from 1.4.9 to 1.4.10
- Update package.json, package-lock.json, CHANGELOG.md

## Changes since v1.4.9
- **fix**: Dashboard real-time updates — thread subscribe + bot_registered broadcast (#225, PR #226)
- **fix**: Review findings — stale closure, double handling, type safety, CONNECTING race

## Post-merge
Create GitHub Release with tag `v1.4.10` from merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)