### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.5.0] - 2026-03-19
+
+### Added
+- **Bot join approval mechanism** — New `join_status` field on bots, `join_approval_required` on orgs. Ticket registration respects approval setting; auth middleware enforces pending/rejected bots (403 HTTP, 4403 WS). Admin approval API (`PATCH /api/org/bots/:id/status`) with idempotent design. WebSocket events: `bot_join_request`, `bot_status_changed` (#229)
+- **Thread search API** — `GET /api/threads?q=xxx&scope=org` searches thread topics with LIKE, returns `participant_count` and `is_participant` per result. Cursor pagination, sorted by `last_activity_at` DESC, limit 1–50 (#228)
+- **Skip-approval tickets** — `skip_approval` flag on `org_tickets` allows trusted bots to bypass join approval even when org requires it. Dashboard ticket creation UI includes the option (#234)
+- **Dashboard hash routing** — Static-export-compatible hash-based routing (`#/bots`, `#/threads`, `#/settings`) with deep linking and browser navigation support (#231)
+- **Org settings page** — Dashboard `#/settings` view exposing join approval toggle, message rate limits, thread auto-close days, artifact retention. Inline editing with per-field save (#232)
+- **Bot approval UI** — Dashboard bot list with pending/rejected status badges, approval banner with approve/reject buttons, reject confirmation dialog, real-time WebSocket refresh (#233)
+
+### Fixed
+- **TS2367 compilation error** — Extracted `isAdminRequest()` helper with type assertion to resolve TypeScript type narrowing issue across 4 admin checks (#230)
+- **Admin bot event delivery** — `notifyAdminsOfJoinRequest()` now checks `client.botId` against admin bot ID set in addition to `isOrgAdmin` session flag (#235)
+
 ## [1.4.10] - 2026-03-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hxa-connect",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hxa-connect",
-      "version": "1.4.10",
+      "version": "1.5.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "better-sqlite3": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hxa-connect",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "description": "Bot-to-Bot Communication Hub — lightweight, self-hostable messaging infrastructure for AI bots",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 1.5.0
- Update CHANGELOG.md with all changes since v1.4.10

### Included features (already merged to main)
- **Bot join approval mechanism** — join_status field, auth enforcement, admin API, WS events (#229)
- **Thread search API** — GET /api/threads?q=xxx&scope=org with cursor pagination (#228)
- **Skip-approval tickets** — skip_approval flag on org_tickets (#234)
- **Dashboard hash routing** — Static-export-compatible hash routing (#231)
- **Org settings page** — #/settings with join approval toggle and other org configs (#232)
- **Bot approval UI** — Status badges, approve/reject buttons, real-time updates (#233)
- **TS2367 fix** — isAdminRequest() helper extraction (#230)
- **Admin bot event delivery fix** — Check botId against admin set (#235)

### DB migration notes (production)
Two new auto-migrations run on startup:
1. `bot_join_approval` — Adds 4 columns to `bots` table + 1 to `orgs` table
2. `ticket_skip_approval` — Adds 1 column to `org_tickets` table

All use `ALTER TABLE ADD COLUMN` with sensible defaults. Fully backward compatible — existing data unaffected. Migrations are idempotent (tracked in `schema_versions` table). No manual SQL required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)