### PR TITLE
fix: sync thread updates when deleting bots

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2351,6 +2351,27 @@ export class HubDB {
   }
 
   /**
+   * Returns every thread a bot currently participates in.
+   * Used by destructive flows (for example bot deletion) where the caller needs
+   * to fan out consistency events to every affected thread without pagination.
+   */
+  async getThreadsParticipatedByBot(botId: string): Promise<(Thread & { participant_count: number })[]> {
+    const rows = await this.driver.all<any>(`
+      SELECT t.*, (SELECT COUNT(*) FROM thread_participants tp2 WHERE tp2.thread_id = t.id) AS participant_count
+      FROM threads t
+      JOIN thread_participants tp ON t.id = tp.thread_id
+      WHERE tp.bot_id = ?
+      ORDER BY t.last_activity_at DESC, t.id DESC
+    `, [botId]);
+
+    return rows.map((row: any) => {
+      const count = Number(row.participant_count);
+      delete row.participant_count;
+      return { ...this.rowToThread(row), participant_count: count };
+    });
+  }
+
+  /**
    * Cursor-paginated thread list for a bot.
    * Cursor key: (last_activity_at DESC, id DESC), opaque-encoded.
    * Returns limit+1 rows so the caller can detect has_more.

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -396,6 +396,41 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig, sessionSto
     });
   }
 
+  async function broadcastDeletedBotThreadSync(
+    bot: Bot,
+    removedBy: string,
+    affectedThreads: Array<Thread & { participant_count: number }>,
+  ): Promise<void> {
+    for (const thread of affectedThreads) {
+      try {
+        await ws.broadcastThreadEvent(thread.org_id, thread.id, {
+          type: 'thread_participant',
+          thread_id: thread.id,
+          bot_id: bot.id,
+          bot_name: bot.name,
+          action: 'left',
+          by: removedBy,
+        });
+
+        const autoClosedByDeletion = thread.participant_count === 1
+          && thread.status !== 'resolved'
+          && thread.status !== 'closed';
+        if (!autoClosedByDeletion) continue;
+
+        await ws.broadcastThreadEvent(thread.org_id, thread.id, {
+          type: 'thread_status_changed',
+          thread_id: thread.id,
+          topic: thread.topic,
+          from: thread.status,
+          to: 'closed',
+          by: removedBy,
+        });
+      } catch (err) {
+        routeLogger.error({ err, botId: bot.id, threadId: thread.id }, 'broadcast deleted bot thread sync failed');
+      }
+    }
+  }
+
   async function requireThreadParticipant(
     req: import('express').Request,
     res: import('express').Response,
@@ -1401,12 +1436,16 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig, sessionSto
     // a single transaction. This eliminates the race window entirely — there is
     // no point in time where the name is freed but the tombstone is not in place.
     const deletedBy = req.bot ? req.bot.id : 'session';
+    const threadSyncBy = threadActorRef(req, orgId!);
+    const affectedThreads = await db.getThreadsParticipatedByBot(bot.id);
     await db.deleteBotWithTombstone(bot.id, bot.name, orgId!, deletedBy);
     await db.recordAudit(orgId!, bot.id, 'bot.delete', 'bot', bot.id, { name: bot.name, deleted_by: deletedBy });
 
     // Terminate the deleted bot's active WebSocket connection immediately.
     // Without this, the victim bot's connection stays open and can still receive messages.
     ws.disconnectByBotId(bot.id);
+
+    await broadcastDeletedBotThreadSync(bot, threadSyncBy, affectedThreads);
 
     // Broadcast bot offline to remaining org members
     ws.broadcastToOrg(bot.org_id, {
@@ -1426,11 +1465,14 @@ export function createRouter(db: HubDB, ws: HubWS, config: HubConfig, sessionSto
 
     // #199 A1: Atomically tombstone the bot's name and delete the bot row in
     // a single transaction (same reasoning as DELETE /api/bots/:id above).
+    const affectedThreads = await db.getThreadsParticipatedByBot(bot.id);
     await db.deleteBotWithTombstone(bot.id, bot.name, bot.org_id, bot.id);
 
     // Terminate the self-deleting bot's active WebSocket connection immediately.
     // Without this, the connection stays open even though the token is now invalid.
     ws.disconnectByBotId(bot.id);
+
+    await broadcastDeletedBotThreadSync(bot, bot.id, affectedThreads);
 
     // Audit
     await db.recordAudit(bot.org_id, bot.id, 'bot.delete', 'bot', bot.id, { name: bot.name, self: true });

--- a/test/dashboard-realtime.test.ts
+++ b/test/dashboard-realtime.test.ts
@@ -80,7 +80,7 @@ describe('Dashboard Real-Time Updates (#225)', () => {
     // Register a bot
     const r1 = await env.registerBot(org.org_secret, 'alpha');
     bot1Token = r1.token;
-    bot1Id = r1.bot.bot_id;
+    bot1Id = r1.bot.bot_id || r1.bot.id;
 
     // Login as org admin
     adminCookie = await env.loginAsOrg(org.org_secret);
@@ -252,6 +252,96 @@ describe('Dashboard Real-Time Updates (#225)', () => {
         adminWs.close();
         botWs.close();
         bot2Ws.close();
+      }
+    });
+
+    it('bot deletion emits thread_participant left for subscribed org_admin and keeps thread detail counts aligned', async () => {
+      const adminWs = await connectAdminWs(env.baseUrl, adminCookie);
+      const r2 = await env.registerBot(org.org_secret, 'beta-delete');
+      const betaId = r2.bot.bot_id || r2.bot.id;
+
+      try {
+        const { status: createStatus, body: thread } = await api(env.baseUrl, 'POST', '/api/threads', {
+          token: bot1Token,
+          body: { topic: 'participant-delete-test', participants: [betaId] },
+        });
+        expect(createStatus).toBe(200);
+
+        wsSend(adminWs, { type: 'subscribe', thread_id: thread.id });
+        await new Promise(r => setTimeout(r, 100));
+
+        const eventsPromise = collectMessages(adminWs, 500);
+        const { status: deleteStatus } = await api(env.baseUrl, 'DELETE', `/api/bots/${betaId}`, {
+          cookie: adminCookie,
+        });
+        expect(deleteStatus).toBe(200);
+
+        const events = await eventsPromise;
+        expect(events).toContainEqual(expect.objectContaining({
+          type: 'thread_participant',
+          thread_id: thread.id,
+          bot_id: betaId,
+          bot_name: 'beta-delete',
+          action: 'left',
+        }));
+
+        const adminThread = await api(env.baseUrl, 'GET', `/api/org/threads/${thread.id}`, { cookie: adminCookie });
+        const botThread = await api(env.baseUrl, 'GET', `/api/threads/${thread.id}`, { token: bot1Token });
+        expect(adminThread.status).toBe(200);
+        expect(botThread.status).toBe(200);
+        expect(adminThread.body.participant_count).toBe(1);
+        expect(botThread.body.participant_count).toBe(1);
+        expect(adminThread.body.participants.map((p: { bot_id: string }) => p.bot_id)).toEqual([bot1Id]);
+        expect(botThread.body.participants.map((p: { bot_id: string }) => p.bot_id)).toEqual([bot1Id]);
+      } finally {
+        adminWs.close();
+      }
+    });
+
+    it('bot deletion emits thread_participant left and thread_status_changed for subscribed org_admin when the deleted bot was the last participant', async () => {
+      const adminWs = await connectAdminWs(env.baseUrl, adminCookie);
+      const solo = await env.registerBot(org.org_secret, 'solo-delete');
+      const soloId = solo.bot.bot_id || solo.bot.id;
+
+      try {
+        const { status: createStatus, body: thread } = await api(env.baseUrl, 'POST', '/api/threads', {
+          token: solo.token,
+          body: { topic: 'solo-delete-test' },
+        });
+        expect(createStatus).toBe(200);
+
+        wsSend(adminWs, { type: 'subscribe', thread_id: thread.id });
+        await new Promise(r => setTimeout(r, 100));
+
+        const eventsPromise = collectMessages(adminWs, 500);
+        const { status: deleteStatus } = await api(env.baseUrl, 'DELETE', `/api/bots/${soloId}`, {
+          cookie: adminCookie,
+        });
+        expect(deleteStatus).toBe(200);
+
+        const events = await eventsPromise;
+        expect(events).toContainEqual(expect.objectContaining({
+          type: 'thread_participant',
+          thread_id: thread.id,
+          bot_id: soloId,
+          bot_name: 'solo-delete',
+          action: 'left',
+        }));
+        expect(events).toContainEqual(expect.objectContaining({
+          type: 'thread_status_changed',
+          thread_id: thread.id,
+          topic: 'solo-delete-test',
+          from: 'active',
+          to: 'closed',
+        }));
+
+        const adminThread = await api(env.baseUrl, 'GET', `/api/org/threads/${thread.id}`, { cookie: adminCookie });
+        expect(adminThread.status).toBe(200);
+        expect(adminThread.body.status).toBe('closed');
+        expect(adminThread.body.participant_count).toBe(0);
+        expect(adminThread.body.participants).toEqual([]);
+      } finally {
+        adminWs.close();
       }
     });
 

--- a/test/web-ui.test.ts
+++ b/test/web-ui.test.ts
@@ -371,18 +371,20 @@ describe('WebSocket ticket via session', () => {
 // ─── Web UI Static Files ───────────────────────────────────
 
 describe('Web UI static files', () => {
-  it('frontend files exist in web/ui/', async () => {
+  it('frontend source files exist in web-next/', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');
-    const webDir = path.resolve(import.meta.dirname, '..', 'web', 'ui');
+    const webDir = path.resolve(import.meta.dirname, '..', 'web-next');
+    const pagePath = path.join(webDir, 'src', 'app', 'page.tsx');
+    const cssPath = path.join(webDir, 'src', 'styles', 'globals.css');
 
-    expect(fs.existsSync(path.join(webDir, 'index.html'))).toBe(true);
-    expect(fs.existsSync(path.join(webDir, 'ui.css'))).toBe(true);
+    expect(fs.existsSync(pagePath)).toBe(true);
+    expect(fs.existsSync(cssPath)).toBe(true);
 
-    const html = fs.readFileSync(path.join(webDir, 'index.html'), 'utf8');
-    expect(html).toContain('HXA Web UI');
+    const page = fs.readFileSync(pagePath, 'utf8');
+    expect(page).toContain('HXA-Connect');
 
-    const css = fs.readFileSync(path.join(webDir, 'ui.css'), 'utf8');
-    expect(css).toContain('--accent');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    expect(css).toContain('--color-hxa-accent');
   });
 });


### PR DESCRIPTION
## Summary
- confirm issue #258 is not caused by divergent admin/bot GET members endpoints on latest `main`
- fix the real-time inconsistency by broadcasting `thread_participant:left` for every thread affected by bot deletion
- also broadcast `thread_status_changed` when deleting the last participant auto-closes a thread
- add regression coverage for both deletion paths and update the stale frontend-path test to the current `web-next` layout

## Verification
- `npm test`
- `npm run build`

## Issue
- Closes #258