### PR TITLE
fix(deps): patch path-to-regexp ReDoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,9 +2399,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE",
   "overrides": {
+    "path-to-regexp": "0.1.13",
     "picomatch": "4.0.4"
   },
   "dependencies": {

--- a/test/web-ui.test.ts
+++ b/test/web-ui.test.ts
@@ -371,18 +371,20 @@ describe('WebSocket ticket via session', () => {
 // ─── Web UI Static Files ───────────────────────────────────
 
 describe('Web UI static files', () => {
-  it('frontend files exist in web/ui/', async () => {
+  it('frontend source files exist in web-next/', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');
-    const webDir = path.resolve(import.meta.dirname, '..', 'web', 'ui');
+    const webDir = path.resolve(import.meta.dirname, '..', 'web-next');
+    const pagePath = path.join(webDir, 'src', 'app', 'page.tsx');
+    const cssPath = path.join(webDir, 'src', 'styles', 'globals.css');
 
-    expect(fs.existsSync(path.join(webDir, 'index.html'))).toBe(true);
-    expect(fs.existsSync(path.join(webDir, 'ui.css'))).toBe(true);
+    expect(fs.existsSync(pagePath)).toBe(true);
+    expect(fs.existsSync(cssPath)).toBe(true);
 
-    const html = fs.readFileSync(path.join(webDir, 'index.html'), 'utf8');
-    expect(html).toContain('HXA Web UI');
+    const page = fs.readFileSync(pagePath, 'utf8');
+    expect(page).toContain('HXA-Connect');
 
-    const css = fs.readFileSync(path.join(webDir, 'ui.css'), 'utf8');
-    expect(css).toContain('--accent');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    expect(css).toContain('--color-hxa-accent');
   });
 });


### PR DESCRIPTION
## Summary
- patch the high-severity `path-to-regexp` ReDoS reported in dependabot alert #10
- pin the transitive dependency to `0.1.13` via `overrides` without changing the Express major version
- update the stale Web UI path assertion so the current `web-next` layout still passes in CI

## Impact
- Layer: Connector/server
- Protocol impact: none
- Downstream impact: none expected beyond the patched dependency resolution
- Rollback: revert this PR to restore the previous lockfile and dependency graph

## Verification
- `npm audit --json`
- `npm test`
- `npm run build`