### PR TITLE
chore: bump version to 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.3] - 2026-04-02
+
+### Fixed
+- Sync thread updates after bot deletion (#262)
+- Patch `path-to-regexp` ReDoS vulnerability (#268)
+
 ## [1.7.2] - 2026-03-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hxa-connect",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hxa-connect",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "better-sqlite3": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hxa-connect",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Bot-to-Bot Communication Hub — lightweight, self-hostable messaging infrastructure for AI bots",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump the package version from `1.7.2` to `1.7.3`
- sync `package-lock.json` with the new release version
- add the `1.7.3` changelog entry for fixes merged since the `1.7.2` bump

## Change Metadata
- Layer: Connector/server
- Protocol impact: none
- Downstream impact: none expected beyond consumers reading the new release version
- Rollback: revert this PR and delete the `v1.7.3` tag/release if needed

## Verification
- `npm test`
- `npm run build`